### PR TITLE
feat: add custom instructions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,48 @@ An MCP server implementation that integrates with Odoo ERP systems, enabling AI 
    * `ODOO_TIMEOUT`: Connection timeout in seconds (default: 30)
    * `ODOO_VERIFY_SSL`: Whether to verify SSL certificates (default: true)
    * `HTTP_PROXY`: Force the ODOO connection to use an HTTP proxy
+   * `ODOO_CUSTOM_INSTRUCTIONS`: Path to a text file containing custom instructions to append to all tool descriptions
+
+### Custom Instructions
+
+You can provide custom instructions that will be appended to all tool descriptions. This is useful for providing context-specific guidance or organizational conventions.
+
+1. Create a text file with your instructions (e.g., `odoo_instructions.txt`):
+
+```text
+When working with this Odoo instance:
+- Always use Spanish for field labels
+- The fiscal year starts in July
+- Contact the IT department before modifying res.users records
+```
+
+2. Set the environment variable to point to your file:
+
+```bash
+export ODOO_CUSTOM_INSTRUCTIONS="/path/to/odoo_instructions.txt"
+```
+
+3. Or add it to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "odoo": {
+      "command": "python",
+      "args": ["-m", "odoo_mcp"],
+      "env": {
+        "ODOO_URL": "https://your-odoo-instance.com",
+        "ODOO_DB": "your-database-name",
+        "ODOO_USERNAME": "your-username",
+        "ODOO_PASSWORD": "your-password-or-api-key",
+        "ODOO_CUSTOM_INSTRUCTIONS": "/path/to/odoo_instructions.txt"
+      }
+    }
+  }
+}
+```
+
+The instructions will be automatically included in all tool descriptions, helping the AI assistant follow your specific guidelines.
 
 ### Usage with Claude Desktop
 

--- a/src/odoo_mcp/server.py
+++ b/src/odoo_mcp/server.py
@@ -5,6 +5,7 @@ Provides MCP tools and resources for interacting with Odoo ERP systems
 """
 
 import json
+import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -14,6 +15,12 @@ from mcp.server.fastmcp import Context, FastMCP
 from pydantic import BaseModel, Field
 
 from .odoo_client import OdooClient, get_odoo_client
+
+# Load custom instructions from environment variable
+CUSTOM_INSTRUCTIONS = ""
+if "ODOO_CUSTOM_INSTRUCTIONS" in os.environ:
+    with open(os.environ["ODOO_CUSTOM_INSTRUCTIONS"]) as f:
+        CUSTOM_INSTRUCTIONS = f.read()
 
 
 @dataclass
@@ -211,7 +218,7 @@ class SearchHolidaysResponse(BaseModel):
 # ----- MCP Tools -----
 
 
-@mcp.tool(description="Execute a custom method on an Odoo model")
+@mcp.tool()
 def execute_method(
     ctx: Context,
     model: str,
@@ -219,8 +226,7 @@ def execute_method(
     args: List = None,
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """
-    Execute a custom method on an Odoo model
+    f"""Execute a custom method on an Odoo model
 
     Parameters:
         model: The model name (e.g., 'res.partner')
@@ -233,6 +239,8 @@ def execute_method(
         - success: Boolean indicating success
         - result: Result of the method (if success)
         - error: Error message (if failure)
+
+    {CUSTOM_INSTRUCTIONS}
     """
     odoo = ctx.request_context.lifespan_context.odoo
     try:
@@ -348,14 +356,13 @@ def execute_method(
         return {"success": False, "error": str(e)}
 
 
-@mcp.tool(description="Search for employees by name")
+@mcp.tool()
 def search_employee(
     ctx: Context,
     name: str,
     limit: int = 20,
 ) -> SearchEmployeeResponse:
-    """
-    Search for employees by name using Odoo's name_search method.
+    f"""Search for employees by name using Odoo's name_search method
 
     Parameters:
         name: The name (or part of the name) to search for.
@@ -363,6 +370,8 @@ def search_employee(
 
     Returns:
         SearchEmployeeResponse containing results or error information.
+
+    {CUSTOM_INSTRUCTIONS}
     """
     odoo = ctx.request_context.lifespan_context.odoo
     model = "hr.employee"
@@ -381,15 +390,14 @@ def search_employee(
         return SearchEmployeeResponse(success=False, error=str(e))
 
 
-@mcp.tool(description="Search for holidays within a date range")
+@mcp.tool()
 def search_holidays(
     ctx: Context,
     start_date: str,
     end_date: str,
     employee_id: Optional[int] = None,
 ) -> SearchHolidaysResponse:
-    """
-    Searches for holidays within a specified date range.
+    f"""Search for holidays within a specified date range
 
     Parameters:
         start_date: Start date in YYYY-MM-DD format.
@@ -397,7 +405,9 @@ def search_holidays(
         employee_id: Optional employee ID to filter holidays.
 
     Returns:
-        SearchHolidaysResponse:  Object containing the search results.
+        SearchHolidaysResponse: Object containing the search results.
+
+    {CUSTOM_INSTRUCTIONS}
     """
     odoo = ctx.request_context.lifespan_context.odoo
 


### PR DESCRIPTION
Add support for custom instructions that can be appended to all tool descriptions via the ODOO_CUSTOM_INSTRUCTIONS environment variable.

This feature allows users to provide context-specific guidance or organizational conventions that will be included in all tool descriptions, similar to the implementation in mcp-redmine.

Changes:
- Load custom instructions from file specified in ODOO_CUSTOM_INSTRUCTIONS env var
- Modify all tools to use f-string docstrings that include CUSTOM_INSTRUCTIONS
- Update README.md with documentation and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)