### PR TITLE
fix: XML-RPC marshal-None failures (client allow_none + marshal-safe fields_get)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- XML-RPC transport: create the `ServerProxy` clients with `allow_none=True` so a
+  call whose payload or `fields_get` metadata contains `None` no longer raises
+  `TypeError: cannot marshal None unless allow_none is enabled` (seen when creating
+  a `product.pricelist` through `validate_write`). Odoo's XML-RPC server already
+  emits `<nil/>`, so the client must accept it too.
+
 ## [1.0.0] - 2026-06-11
 
 The v1.0 milestone: four roadmap phases close the highest-value gaps no

--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -152,12 +152,15 @@ class OdooClient:
             timeout=self.timeout, use_https=is_https, verify_ssl=self.verify_ssl
         )
 
-        # Set up XML-RPC endpoints.
+        # Set up XML-RPC endpoints. allow_none=True is required so the client can
+        # marshal None (Odoo's XML-RPC server already emits <nil/>); without it a
+        # write payload or fields_get metadata containing None raises
+        # "cannot marshal None unless allow_none is enabled".
         self._common = xmlrpc.client.ServerProxy(
-            f"{self.url}/xmlrpc/2/common", transport=transport
+            f"{self.url}/xmlrpc/2/common", transport=transport, allow_none=True
         )
         self._models = xmlrpc.client.ServerProxy(
-            f"{self.url}/xmlrpc/2/object", transport=transport
+            f"{self.url}/xmlrpc/2/object", transport=transport, allow_none=True
         )
 
         # Authenticate and capture the user ID.

--- a/tests/test_odoo_client.py
+++ b/tests/test_odoo_client.py
@@ -43,7 +43,7 @@ class FakeJsonResponse:
 def build_client(monkeypatch, odoo_client_module):
     calls = []
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         calls.append(("ServerProxy", endpoint, type(transport).__name__))
         if endpoint.endswith("/xmlrpc/2/common"):
             return FakeCommonProxy(calls)
@@ -120,6 +120,37 @@ def test_client_initialization_creates_common_and_object_xmlrpc_endpoints(
         ),
         ("authenticate", "demo-db", "demo-user", "demo-password", {}),
     ]
+
+
+def test_client_initialization_enables_allow_none_on_xmlrpc_proxies(
+    monkeypatch, odoo_client_module
+):
+    # Odoo's XML-RPC server emits <nil/>, and write payloads / fields_get metadata
+    # can contain None, so both proxies must be created with allow_none=True or
+    # xmlrpc.client raises "cannot marshal None unless allow_none is enabled".
+    seen: dict[str, bool] = {}
+
+    def fake_server_proxy(endpoint, transport, allow_none=False):
+        seen[endpoint.rsplit("/", 1)[-1]] = allow_none
+        if endpoint.endswith("/xmlrpc/2/common"):
+            return FakeCommonProxy([])
+        if endpoint.endswith("/xmlrpc/2/object"):
+            return FakeObjectProxy([])
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(
+        odoo_client_module.xmlrpc.client, "ServerProxy", fake_server_proxy
+    )
+    odoo_client_module.OdooClient(
+        url="odoo.example.test",
+        db="demo-db",
+        username="demo-user",
+        password="demo-password",
+        timeout=3,
+        verify_ssl=False,
+    )
+
+    assert seen == {"common": True, "object": True}
 
 
 def test_execute_method_passes_database_credentials_model_method_args_and_kwargs(
@@ -237,7 +268,7 @@ def test_profile_helpers_read_version_context_and_installed_modules(
                 return [{"name": "base", "shortdesc": "Base", "state": "installed"}]
             raise AssertionError(f"unexpected call: {model}.{method}")
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         calls.append(("ServerProxy", endpoint, type(transport).__name__))
         if endpoint.endswith("/xmlrpc/2/common"):
             return FakeCommonProxy(calls)
@@ -457,7 +488,7 @@ def test_json2_get_server_version_uses_web_version_endpoint(
 def _build_xmlrpc_client_with_lang(monkeypatch, odoo_client_module, lang):
     calls = []
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         if endpoint.endswith("/xmlrpc/2/common"):
             return FakeCommonProxy(calls)
         if endpoint.endswith("/xmlrpc/2/object"):
@@ -621,7 +652,7 @@ def test_xmlrpc_connection_error_during_authenticate_raises_connection_error(
         def authenticate(self, *args, **kwargs):
             raise ConnectionError("network down")
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         if endpoint.endswith("/xmlrpc/2/common"):
             return BoomCommonProxy()
         return BoomCommonProxy()
@@ -645,7 +676,7 @@ def test_xmlrpc_authenticate_returns_falsy_uid_raises_value_error(
         def authenticate(self, *args, **kwargs):
             return 0  # Falsy → "Authentication failed"
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         return FalsyAuthProxy()
 
     monkeypatch.setattr(
@@ -667,7 +698,7 @@ def test_xmlrpc_unexpected_authenticate_error_raises_value_error(
         def authenticate(self, *args, **kwargs):
             raise RuntimeError("something else")
 
-    def fake_server_proxy(endpoint, transport):
+    def fake_server_proxy(endpoint, transport, allow_none=False):
         return BoomProxy()
 
     monkeypatch.setattr(


### PR DESCRIPTION
## What & why

Two related XML-RPC marshal-None failures, found and verified on a live Odoo 19 deployment. The visible symptom for both: creating a `product.pricelist` (IQD) through `validate_write` fails with `cannot marshal None`.

**1. Client-side (`allow_none`)** — `xmlrpc.client.ServerProxy` defaults to `allow_none=False`, so any call whose args/kwargs contain `None` raises `TypeError: cannot marshal None unless allow_none is enabled` before it leaves the client. Odoo's server already emits `<nil/>`, so the client should accept it too. Fixed by constructing both proxies with `allow_none=True`.

**2. Server-side (bounded `fields_get`)** — live testing showed fix 1 is necessary but not sufficient: a **full** `fields_get` faults **server-side** on models whose `domain` attribute is `None` (e.g. `product.pricelist` on Odoo 19) — Odoo's own XML-RPC layer refuses to marshal its response, which no client flag can fix:

```
full fields_get(product.pricelist)              -> xmlrpclib.Fault (server traceback in odoo/addons/rpc/controllers/xmlrpc.py)
fields_get with bounded attributes (no domain)  -> OK, 39 fields
```

`get_model_fields` now requests only the attributes the server consumes (`string, help, type, required, readonly, relation, selection, store, searchable`). An absent attribute reads as `None` via `.get()`, exactly the value the code saw before, so behavior is unchanged apart from the fault disappearing.

## Behavior change

- Calls whose payload contains `None` now succeed (marshalled as `<nil/>`).
- `get_model_fields` responses no longer include attributes outside the bounded list (notably `domain`, the `None` carrier). `validate_write` works on models that previously faulted.
- No effect on the JSON-2 transport.

## Odoo versions tested

Odoo 19.0 — reproduced both failure modes and verified both fixes against a live instance (including a successful `product.pricelist` creation that previously failed).

## Transport tested

XML-RPC.

## Tests run

- `uv run --python 3.12 python -m ruff check .` — clean
- `uv run --python 3.12 python -m mypy src` — clean
- `uv run --python 3.12 python -m pytest` — 856 passed

Added `test_client_initialization_enables_allow_none_on_xmlrpc_proxies` and `test_get_model_fields_requests_bounded_marshal_safe_attributes`; the existing `fake_server_proxy` mocks accept the new `allow_none` kwarg. `CHANGELOG.md` updated under `[Unreleased] → Fixed`.