### PR TITLE
Add additional Odoo model rename mappings

### DIFF
--- a/src/odoo_mcp/data/odoo_renames.json
+++ b/src/odoo_mcp/data/odoo_renames.json
@@ -197,6 +197,48 @@
       "changed_in": "18.0",
       "kind": "renamed",
       "notes": "Chat shortcodes became canned responses."
+    },
+    {
+      "old_model": "hr.leave.stress.day",
+      "new_model": "hr.leave.mandatory.day",
+      "changed_in": "17.0",
+      "kind": "renamed",
+      "notes": "Stress day model renamed to mandatory day."
+    },
+    {
+      "old_model": "mail.channel.rtc.session",
+      "new_model": "discuss.channel.rtc.session",
+      "changed_in": "17.0",
+      "kind": "renamed",
+      "notes": "RTC session model moved to the discuss namespace."
+    },
+    {
+      "old_model": "mailing.contact.subscription",
+      "new_model": "mailing.subscription",
+      "changed_in": "17.0",
+      "kind": "renamed",
+      "notes": "Mailing contact subscriptions renamed."
+    },
+    {
+      "old_model": "payment.icon",
+      "new_model": "payment.method",
+      "changed_in": "17.0",
+      "kind": "renamed",
+      "notes": "Payment icons renamed to payment methods."
+    },
+    {
+      "old_model": "restaurant.printer",
+      "new_model": "pos.printer",
+      "changed_in": "17.0",
+      "kind": "renamed",
+      "notes": "Restaurant printers moved to the POS printer model."
+    },
+    {
+      "old_model": "hr.applicant.skill",
+      "new_model": "hr.candidate.skill",
+      "changed_in": "18.0",
+      "kind": "renamed",
+      "notes": "Applicant skills renamed to candidate skills."
     }
   ]
 }

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -760,6 +760,13 @@ def test_lookup_model_history_resolves_old_name_to_new_model():
     assert report["matches"][0]["new_model"] == "account.move"
     assert any("account.move" in line for line in report["guidance"])
 
+def test_lookup_model_history_resolves_newly_added_model():
+    report = agent_tools.lookup_model_history_report("payment.icon")
+    assert report["success"] is True
+    assert report["match_type"] == "exact"
+    assert report["matches"][0]["new_model"] == "payment.method"
+    assert any("payment.method" in line for line in report["guidance"])
+
 
 def test_lookup_model_history_recognizes_current_name():
     report = agent_tools.lookup_model_history_report("discuss.channel")


### PR DESCRIPTION
## Summary

This PR extends the Odoo model rename catalog by adding six additional model rename mappings for newer Odoo versions. It also adds a regression test to verify one of the newly added mappings (`payment.icon` → `payment.method`).

## Coverage

- Odoo versions tested: Not applicable (catalog data update only)
- Transports tested: Not applicable

## Verification

```bash
uv run pytest tests/test_agent_tools.py -k lookup_model_history
```

**Result:**
- 6 lookup model history tests passed successfully.
- The full test suite currently has unrelated test collection errors (`ModuleNotFoundError: No module named 'tests'`), which are unrelated to this change.

## Checklist

- [ ] Updated `README.md` / `docs/` when behavior changes
- [ ] Updated `CHANGELOG.md` under `## Unreleased`
- [x] No credentials, private database names, or production debug traces in diff or logs
- [x] Write-execution safety gates are unchanged

## Notes for reviewers

- Added six additional verified model rename mappings to `src/odoo_mcp/data/odoo_renames.json`.
- Added a regression test for the `payment.icon` → `payment.method` mapping.
- This PR intentionally keeps the scope small and focused. Additional model renames can be added in follow-up PRs.