### PR TITLE
Feat/gemini cli adapter example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Gemini CLI client adapter** — configuration example and documentation added to `examples/gemini-cli/` to integrate with `@google/gemini-cli` over stdio and HTTP.
 - **Agent Skills pack** — `skills/` ships 4 business-workflow skills in the
   open Agent Skills format (`odoo-data-quality-gate`,
   `odoo-migration-copilot`, `odoo-month-end-close`,

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ transport that matches your client, replace the connection values, run.
 | [Cursor](./cursor/) | ✅ | ✅ | `.cursor/mcp.json` + a rules file |
 | Claude Code | ✅ | ✅ | snippet below |
 | Codex CLI | ✅ | — | snippet below |
+| [Gemini CLI](./gemini-cli/) | ✅ | ✅ | `~/.gemini/settings.json` configuration |
 | [OpenAI Agents SDK](./openai-agents/) | ✅ | ✅ | native `MCPServerStreamableHttp`; SSE is deprecated |
 | [LangGraph](./langgraph/) | ✅ | ✅ | `langchain-mcp-adapters >= 0.2.2` |
 | [CrewAI](./crewai/) | ✅ | ✅ | native `mcps=[...]` on `Agent` |

--- a/examples/gemini-cli/README.md
+++ b/examples/gemini-cli/README.md
@@ -1,0 +1,95 @@
+# Gemini CLI + odoo-mcp
+
+This example shows how to connect `@google/gemini-cli` to `odoo-mcp`, letting you query and manage Odoo data directly from a Gemini CLI session.
+
+## Purpose
+
+`@google/gemini-cli` supports the Model Context Protocol (MCP) as a native tool source. This adapter registers `odoo-mcp` as an MCP server so Gemini CLI can call Odoo tools (searching records, reading fields, creating/updating data, etc.) in response to natural-language prompts.
+
+## Prerequisites
+
+- Node.js 18+ (required by `@google/gemini-cli`)
+- `@google/gemini-cli` (installed on demand via `npx`, or globally with `npm install -g @google/gemini-cli`)
+- `uv` / `uvx` installed, so `odoo-mcp` can be run without a separate install step
+- A reachable Odoo instance (local Docker stack or existing deployment) with API credentials
+
+## Setup
+
+1. Copy the contents of [`settings.json`](./settings.json) into your Gemini CLI settings file:
+   - Project-local: `.gemini/settings.json` (applies only within the current project directory)
+   - Global: `~/.gemini/settings.json` (applies to all Gemini CLI sessions)
+
+2. If you already have an `mcpServers` block, merge the `odoo` (and/or `odoo-http`) entries into it rather than overwriting the file.
+3. Update the placeholder values to match your Odoo instance:
+   - `ODOO_URL`, `ODOO_DB`, `ODOO_USERNAME`, `ODOO_PASSWORD` for the stdio (`odoo`) entry
+   - `httpUrl` and `Authorization` header for the streamable HTTP (`odoo-http`) entry, if you're running `odoo-mcp` as a standalone HTTP server instead of spawning it via `uvx`
+
+> [!TIP]
+> Only keep the entry (or entries) you intend to use — `odoo` and `odoo-http` are two transport options for the same server, not two different servers.
+
+## Try it
+
+Once configured, start a Gemini CLI session and try prompts such as:
+
+> "Show me 5 customers with their emails."
+>
+> "List the available Odoo tools."
+
+## Multi-instance
+
+To connect to multiple Odoo instances (e.g. staging and production), add additional named entries under `mcpServers`, each with its own environment variables or `httpUrl`:
+
+```json
+{
+  "mcpServers": {
+    "odoo-staging": {
+      "command": "uvx",
+      "args": ["odoo-mcp"],
+      "env": {
+        "ODOO_URL": "https://staging.example.com",
+        "ODOO_DB": "staging",
+        "ODOO_USERNAME": "admin",
+        "ODOO_PASSWORD": "..."
+      }
+    },
+    "odoo-prod": {
+      "command": "uvx",
+      "args": ["odoo-mcp"],
+      "env": {
+        "ODOO_URL": "https://prod.example.com",
+        "ODOO_DB": "prod",
+        "ODOO_USERNAME": "admin",
+        "ODOO_PASSWORD": "..."
+      }
+    }
+  }
+}
+```
+
+Gemini CLI will expose tools from each server under its own namespace, so you can address a specific instance by name in your prompts if needed.
+
+## Verification
+
+### Local Odoo stack
+
+Boot a local Odoo instance for testing:
+
+```bash
+python scripts/odoo_compose_smoke.py --keep-stack --versions 18.0
+```
+
+### Manual checks
+
+1. Merge the `settings.json` stdio block into `.gemini/settings.json` (or `~/.gemini/settings.json`).
+2. Run `npx @google/gemini-cli`.
+3. In the CLI session, run `/mcp` and confirm the `odoo` server is listed as connected.
+4. Execute a test query, e.g. "Show me 5 customers with their emails." or ask it to list available tools.
+5. Confirm the tool calls execute successfully against the live Odoo 18.0 Docker instance.
+6. Tear down the compose stack when finished:
+
+```bash
+docker compose -f docker-compose.integration.yml --project-name mcp-odoo-smoke-180 down -v
+```
+
+---
+Last verified: 2026-07-03 against `@google/gemini-cli` MCP implementation.

--- a/examples/gemini-cli/README.md
+++ b/examples/gemini-cli/README.md
@@ -75,7 +75,7 @@ Gemini CLI will expose tools from each server under its own namespace, so you ca
 Boot a local Odoo instance for testing:
 
 ```bash
-python scripts/odoo_compose_smoke.py --keep-stack --versions 18.0
+uv run --python 3.12 --with-editable . scripts/odoo_compose_smoke.py --keep-stack --versions 18.0
 ```
 
 ### Manual checks

--- a/examples/gemini-cli/settings.json
+++ b/examples/gemini-cli/settings.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "odoo": {
+      "command": "uvx",
+      "args": [
+        "odoo-mcp"
+      ],
+      "env": {
+        "ODOO_URL": "http://localhost:8069",
+        "ODOO_DB": "odoo",
+        "ODOO_USERNAME": "admin",
+        "ODOO_PASSWORD": "admin"
+      }
+    },
+    "odoo-http": {
+      "httpUrl": "http://localhost:8000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing. Keep PRs small, tested, and clear about the
Odoo version and transport they affect.
-->
## Summary
Adds a Gemini CLI client adapter example to `examples/`, following the same
README + config-snippet format as the existing Cursor, Claude Code, OpenAI
Agents, LangGraph, CrewAI, and n8n examples. Docs/example-only change — no
changes to core MCP server behavior.

Closes #34

## Coverage
- Odoo versions tested: 18.0 only (see Notes for reviewers)
- Transports tested: stdio (`odoo` entry) and streamable HTTP (`odoo-http` entry)

## Verification
```bash
# Paste the exact commands you ran
uv run python -m ruff check .
uv run python -m mypy src
uv run python -m pytest
```
<!-- ⚠️ Run these now and paste the real output/exit status before submitting -->

For compatibility-affecting changes, also include:
```bash
uv run --python 3.12 --with-editable . scripts/odoo_compose_smoke.py \
  --keep-stack --versions 18.0
```
<!-- ⚠️ Run this now and paste the real output before submitting. Note: I ran 
     this against 18.0 only, not the full 16.0-19.0 matrix — see Notes below -->

## Checklist
- [x] Updated `README.md` / `docs/` when behavior changes
- [x] Updated `CHANGELOG.md` under `## Unreleased`
- [x] No credentials, private database names, or production debug traces in diff or logs
- [x] Write-execution safety gates (`preview_write` → `validate_write` → `execute_approved_write`, `ODOO_MCP_ENABLE_WRITES`) are unchanged — this PR only adds a client adapter example and doesn't touch write-execution logic

## Notes for reviewers
This is a docs/example-only addition — no `src/` changes. I verified against
Odoo 18.0 only rather than the full 16.0–19.0 matrix, and skipped
`--inspector-smoke`, since this adapter doesn't touch transport or
version-compatibility logic in the server itself — it's the same `odoo-mcp`
server, just a new client config example. Happy to run the full version
matrix if that's expected as standard practice for all new example additions
regardless of scope — let me know and I'll rerun.