### PR TITLE
Add typed output schemas for write tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,9 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 module = "odoo_mcp.tools_read"
 disable_error_code = ["return-value"]
+
+# tools_write uses the same protocol-level response model pattern for typed
+# MCP outputSchema while preserving the existing dict envelopes at runtime.
+[[tool.mypy.overrides]]
+module = "odoo_mcp.tools_write"
+disable_error_code = ["return-value"]

--- a/src/odoo_mcp/schemas.py
+++ b/src/odoo_mcp/schemas.py
@@ -142,3 +142,56 @@ class AggregateRecordsResponse(ToolResponse):
     rows: Optional[List[Dict[str, Any]]] = Field(
         default=None, description="Aggregated group rows."
     )
+
+
+class PreviewWriteResponse(ToolResponse):
+    model: Optional[str] = None
+    operation: Optional[str] = None
+    approval: Optional[Dict[str, Any]] = Field(
+        default=None, description="Canonical payload plus approval token."
+    )
+    execute_method: Optional[Dict[str, Any]] = Field(
+        default=None, description="Equivalent Odoo RPC call preview."
+    )
+    issues: Optional[List[Dict[str, Any]]] = None
+    warnings: Optional[List[Dict[str, Any]]] = None
+    metadata_used: Optional[Dict[str, Any]] = None
+
+
+class ValidateWriteResponse(ToolResponse):
+    model: Optional[str] = None
+    operation: Optional[str] = None
+    issues: Optional[List[Dict[str, Any]]] = None
+    field_hints: Optional[List[Dict[str, Any]]] = None
+    approval: Optional[Dict[str, Any]] = Field(
+        default=None, description="Approval payload when validation succeeds."
+    )
+    approval_status: Optional[Dict[str, Any]] = Field(
+        default=None, description="Whether the approval was stored for execution."
+    )
+    metadata_used: Optional[Dict[str, Any]] = None
+
+
+class ExecuteApprovedWriteResponse(ToolResponse):
+    model: Optional[str] = None
+    operation: Optional[str] = None
+    result: Optional[Any] = Field(default=None, description="Odoo RPC result.")
+    instance: Optional[str] = None
+
+
+class ChatterPostResponse(ToolResponse):
+    mode: Optional[str] = Field(default=None, description="preview, execute, or direct.")
+    model: Optional[str] = None
+    record_id: Optional[int] = None
+    approval_required: Optional[bool] = None
+    approval: Optional[Dict[str, Any]] = None
+    warnings: Optional[List[str]] = None
+    result: Optional[Any] = Field(default=None, description="Odoo message_post result.")
+
+
+class ExecuteMethodResponse(ToolResponse):
+    result: Optional[Any] = Field(default=None, description="Odoo method result.")
+    classification: Optional[Dict[str, Any]] = Field(
+        default=None, description="Safety classification for blocked side effects."
+    )
+    rate_limited: Optional[bool] = None

--- a/src/odoo_mcp/tools_write.py
+++ b/src/odoo_mcp/tools_write.py
@@ -26,6 +26,13 @@ from .tool_helpers import (
 )
 from .write_policy import chatter_direct_enabled, side_effect_method_allowed, writes_enabled
 from .rate_limit import check_rate
+from .schemas import (
+    ChatterPostResponse,
+    ExecuteApprovedWriteResponse,
+    ExecuteMethodResponse,
+    PreviewWriteResponse,
+    ValidateWriteResponse,
+)
 from .server_core import (
     DESTRUCTIVE_TOOL,
     PREVIEW_TOOL,
@@ -108,7 +115,7 @@ def preview_write(
     record_ids: Optional[List[int]] = None,
     context: Optional[Dict[str, Any]] = None,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> PreviewWriteResponse:
     """Build a canonical approval token for a later approved write.
 
     Batch create: pass ``values_list`` (one dict per record, max 100) —
@@ -155,7 +162,7 @@ def validate_write(
     fields_metadata: Optional[Dict[str, Any]] = None,
     use_live_metadata: bool = True,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> ValidateWriteResponse:
     """Validate write shape and return an approval payload when safe."""
     try:
         validate_model_name(model)
@@ -245,7 +252,7 @@ async def execute_approved_write_tool(
     ctx: Context,
     approval: Dict[str, Any],
     confirm: bool = False,
-) -> Dict[str, Any]:
+) -> ExecuteApprovedWriteResponse:
     """Tool entry point: optional human elicitation gate, then the sync gates."""
     decision, detail = await _elicit_write_confirmation(ctx, approval)
     if decision == "declined":
@@ -270,7 +277,7 @@ def execute_approved_write(
     ctx: Context,
     approval: Dict[str, Any],
     confirm: bool = False,
-) -> Dict[str, Any]:
+) -> ExecuteApprovedWriteResponse:
     """Execute create/write/unlink only after token, confirm, and env gates pass."""
     report = _execute_approved_write_gated(ctx, approval, confirm)
     safe_record_ids = [
@@ -430,7 +437,7 @@ def chatter_post(
     approval: Optional[Dict[str, Any]] = None,
     confirm: bool = False,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> ChatterPostResponse:
     """Post a message on the chatter of a mail.thread-derived record.
 
     Modes:
@@ -553,7 +560,7 @@ def execute_method(
     args: Optional[List[Any]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> ExecuteMethodResponse:
     """
     Execute a custom method on an Odoo model
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,6 +19,14 @@ TYPED_READ_TOOLS = {
     "aggregate_records": "rows",
 }
 
+TYPED_WRITE_TOOLS = {
+    "preview_write": "approval",
+    "validate_write": "approval_status",
+    "execute_approved_write": "result",
+    "chatter_post": "mode",
+    "execute_method": "result",
+}
+
 
 def _tools_by_name():
     tools = asyncio.run(server.mcp.list_tools())
@@ -28,6 +36,18 @@ def _tools_by_name():
 def test_read_tools_expose_typed_output_schemas():
     tools = _tools_by_name()
     for name, marker_field in TYPED_READ_TOOLS.items():
+        schema = tools[name].outputSchema
+        assert schema is not None, name
+        props = schema.get("properties", {})
+        # Typed = more than a generic object wrapper: envelope + payload field.
+        assert "success" in props, name
+        assert "error" in props, name
+        assert marker_field in props, (name, sorted(props))
+
+
+def test_write_tools_expose_typed_output_schemas():
+    tools = _tools_by_name()
+    for name, marker_field in TYPED_WRITE_TOOLS.items():
         schema = tools[name].outputSchema
         assert schema is not None, name
         props = schema.get("properties", {})


### PR DESCRIPTION
## Summary

- add Pydantic response models for the five write-domain tools
- annotate write tool return types so FastMCP exposes typed outputSchema payload fields
- extend schema coverage with marker-field assertions for write tools
- add the matching mypy override because runtime responses intentionally remain dict envelopes

Fixes #28

## Validation

- `uv run --extra dev python -m pytest tests/test_schemas.py`
- `uv run --python 3.11 --extra dev python -m pytest tests/test_agent_tools.py::test_scan_addons_source_handles_stat_oserror tests/test_schemas.py`
- `uv run --python 3.11 --extra dev python -m ruff check .`
- `uv run --python 3.11 --extra dev python -m mypy src`
- `PYTHONPATH=src uv run --extra dev --with import-linter lint-imports`
- `git diff --check`

Note: the full suite reached 885 passed / 1 failed locally on Windows under Python 3.11 due `tests/test_task_queue.py::test_list_tasks_newest_first` ordering `first` before `second`; that test passes when run in isolation and this PR does not touch task queue code. Under uv-selected Python 3.14, the full suite also hits an unrelated `Path.stat` monkeypatch assertion in `tests/test_agent_tools.py::test_scan_addons_source_handles_stat_oserror`, while the same test passes under supported Python 3.11.