### PR TITLE
feat(tools): describe MCP tool input parameters

### DIFF
--- a/src/odoo_mcp/tools_accounting.py
+++ b/src/odoo_mcp/tools_accounting.py
@@ -8,9 +8,10 @@ path; the gated write workflow remains the only mutation surface.
 """
 
 from datetime import date
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Dict, Optional
 
 from mcp.server.fastmcp import Context
+from pydantic import Field
 
 from .accounting_tools import (
     MAX_AGING_LINES,
@@ -50,11 +51,23 @@ def build_direction_aging(
 )
 def receivable_payable_aging(
     ctx: Context,
-    direction: str = "receivable",
-    as_of: Optional[str] = None,
-    top_partners: int = 15,
-    limit: int = MAX_AGING_LINES,
-    instance: Optional[str] = None,
+    direction: Annotated[
+        str, Field(description="Aging direction: 'receivable' or 'payable'.")
+    ] = "receivable",
+    as_of: Annotated[
+        Optional[str],
+        Field(description="Optional ISO date used as the aging reference date."),
+    ] = None,
+    top_partners: Annotated[
+        int, Field(description="Maximum top partners to include; capped at 100.")
+    ] = 15,
+    limit: Annotated[
+        int, Field(description="Maximum open-item lines to inspect.")
+    ] = MAX_AGING_LINES,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> Dict[str, Any]:
     """Bucket open posted items (not due / 1-30 / 31-60 / 61-90 / 90+ days).
 

--- a/src/odoo_mcp/tools_cross_instance.py
+++ b/src/odoo_mcp/tools_cross_instance.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Dict, List, Optional
+from typing import Annotated, Any, Callable, Dict, List, Optional
 
 from mcp.server.fastmcp import Context
+from pydantic import Field
 
 from .accounting_tools import build_aging_report, fetch_aging_lines, parse_as_of
 from .audit import record_write_event
@@ -305,10 +306,20 @@ def aggregate_across_instances(
 )
 def accounting_health_across_instances(
     ctx: Context,
-    direction: str = "receivable",
-    as_of: Optional[str] = None,
-    top_partners: int = 10,
-    instances: Optional[Any] = None,
+    direction: Annotated[
+        str, Field(description="Aging direction: 'receivable' or 'payable'.")
+    ] = "receivable",
+    as_of: Annotated[
+        Optional[str],
+        Field(description="Optional ISO date used as the aging reference date."),
+    ] = None,
+    top_partners: Annotated[
+        int, Field(description="Maximum top partners to include in each aging report; capped at 100.")
+    ] = 10,
+    instances: Annotated[
+        Optional[Any],
+        Field(description="Optional instance selector; defaults to all eligible instances."),
+    ] = None,
 ) -> Dict[str, Any]:
     """Aged receivable/payable across every client DB, with combined buckets.
 

--- a/src/odoo_mcp/tools_diagnostics.py
+++ b/src/odoo_mcp/tools_diagnostics.py
@@ -6,9 +6,10 @@ diagnose_access, upgrade_risk_report, lookup_model_history, fit_gap_report,
 scan_addons_source, build_domain, business_pack_report.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.server.fastmcp import Context
+from pydantic import Field
 
 from .access_helpers import (
     _access_diagnosis_codes,
@@ -63,16 +64,36 @@ def _srv() -> Any:
     structured_output=True,
 )
 def diagnose_odoo_call(
-    model: str,
-    method: str,
-    args: Optional[List[Any]] = None,
-    kwargs: Optional[Dict[str, Any]] = None,
-    transport: str = "auto",
-    target_version: Optional[str] = None,
-    observed_error: Optional[Any] = None,
-    include_debug: bool = False,
-    metadata: Optional[Dict[str, Any]] = None,
-    use_live_metadata: bool = False,
+    model: Annotated[str, Field(description="Technical Odoo model name to diagnose.")],
+    method: Annotated[str, Field(description="Odoo model method name to diagnose.")],
+    args: Annotated[
+        Optional[List[Any]], Field(description="Optional positional call arguments.")
+    ] = None,
+    kwargs: Annotated[
+        Optional[Dict[str, Any]], Field(description="Optional keyword call arguments.")
+    ] = None,
+    transport: Annotated[
+        str, Field(description="Transport to assess, such as 'auto', 'xmlrpc', or 'json2'.")
+    ] = "auto",
+    target_version: Annotated[
+        Optional[str], Field(description="Optional target Odoo version for compatibility checks.")
+    ] = None,
+    observed_error: Annotated[
+        Optional[Any], Field(description="Optional error text or structured error to classify.")
+    ] = None,
+    include_debug: Annotated[
+        bool, Field(description="Whether to include additional diagnostic details.")
+    ] = False,
+    metadata: Annotated[
+        Optional[Dict[str, Any]],
+        Field(description="Optional model or method metadata used by the diagnosis."),
+    ] = None,
+    use_live_metadata: Annotated[
+        bool,
+        Field(
+            description="Whether to request live metadata; this preview tool does not fetch it."
+        ),
+    ] = False,
 ) -> Dict[str, Any]:
     """Diagnose model/method/payload issues without executing the candidate call."""
     report = diagnose_odoo_call_report(
@@ -179,15 +200,33 @@ def inspect_model_relationships(
 )
 def diagnose_access(
     ctx: Context,
-    model: str,
-    operation: str = "read",
-    domain: Optional[Any] = None,
-    record_ids: Optional[List[int]] = None,
-    expected_count: Optional[int] = None,
-    include_rules: bool = True,
-    observed_error: Optional[Any] = None,
-    limit: int = 50,
-    instance: Optional[str] = None,
+    model: Annotated[str, Field(description="Technical Odoo model name to inspect.")],
+    operation: Annotated[
+        str, Field(description="Access operation to diagnose, such as read or write.")
+    ] = "read",
+    domain: Annotated[
+        Optional[Any], Field(description="Optional Odoo domain used for the visibility check.")
+    ] = None,
+    record_ids: Annotated[
+        Optional[List[int]], Field(description="Optional record IDs to check directly.")
+    ] = None,
+    expected_count: Annotated[
+        Optional[int],
+        Field(description="Optional expected visible record count for comparison."),
+    ] = None,
+    include_rules: Annotated[
+        bool, Field(description="Whether to include matching record-rule metadata.")
+    ] = True,
+    observed_error: Annotated[
+        Optional[Any], Field(description="Optional error text or structured error to classify.")
+    ] = None,
+    limit: Annotated[
+        int, Field(description="Maximum metadata rows to inspect; capped at 500.")
+    ] = 50,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> Dict[str, Any]:
     """
     Inspect readable ACL/rule metadata for the current Odoo credential.
@@ -463,14 +502,37 @@ def diagnose_access(
     structured_output=True,
 )
 def upgrade_risk_report(
-    source_version: Optional[str] = None,
-    target_version: Optional[str] = None,
-    modules: Optional[List[Dict[str, Any]]] = None,
-    methods: Optional[List[Dict[str, Any]]] = None,
-    source_findings: Optional[List[Dict[str, Any]]] = None,
-    observed_errors: Optional[List[Any]] = None,
-    use_live_metadata: bool = False,
-    include_debug: bool = False,
+    source_version: Annotated[
+        Optional[str], Field(description="Optional current Odoo version.")
+    ] = None,
+    target_version: Annotated[
+        Optional[str], Field(description="Optional target Odoo version.")
+    ] = None,
+    modules: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(description="Optional module metadata to assess for upgrade risks."),
+    ] = None,
+    methods: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(description="Optional model method metadata to assess for compatibility."),
+    ] = None,
+    source_findings: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(description="Optional source-code findings to include in the risk report."),
+    ] = None,
+    observed_errors: Annotated[
+        Optional[List[Any]],
+        Field(description="Optional observed upgrade or migration errors to classify."),
+    ] = None,
+    use_live_metadata: Annotated[
+        bool,
+        Field(
+            description="Whether to request live metadata; this preview tool does not fetch it."
+        ),
+    ] = False,
+    include_debug: Annotated[
+        bool, Field(description="Whether to include additional diagnostic details.")
+    ] = False,
 ) -> Dict[str, Any]:
     """Build an input-driven upgrade risk report without executing Odoo calls."""
     report = build_upgrade_risk_report(
@@ -626,9 +688,20 @@ def build_domain(
 )
 def business_pack_report(
     ctx: Context,
-    pack: str,
-    use_live_metadata: bool = True,
-    instance: Optional[str] = None,
+    pack: Annotated[
+        str,
+        Field(
+            description="Business pack to report, such as sales, crm, inventory, accounting, or hr."
+        ),
+    ],
+    use_live_metadata: Annotated[
+        bool,
+        Field(description="Whether to inspect live models and installed modules."),
+    ] = True,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> Dict[str, Any]:
     """Summarize a domain pack such as sales, crm, inventory, accounting, or hr."""
     try:

--- a/src/odoo_mcp/tools_read.py
+++ b/src/odoo_mcp/tools_read.py
@@ -8,9 +8,10 @@ search_holidays, list_instances, get_odoo_profile, health_check.
 
 import json
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.server.fastmcp import Context
+from pydantic import Field
 
 from .agent_tools import (
     DEFAULT_MAX_RELEVANT_FIELDS,
@@ -69,9 +70,16 @@ def _srv() -> Any:
 )
 def get_odoo_profile(
     ctx: Context,
-    include_modules: bool = True,
-    module_limit: int = 100,
-    instance: Optional[str] = None,
+    include_modules: Annotated[
+        bool, Field(description="Whether to include installed-module metadata.")
+    ] = True,
+    module_limit: Annotated[
+        int, Field(description="Maximum installed modules to include; capped at 500.")
+    ] = 100,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> GetOdooProfileResponse:
     """Return server, user-context, transport, and installed-module metadata."""
     try:
@@ -114,12 +122,26 @@ def get_odoo_profile(
 )
 def schema_catalog(
     ctx: Context,
-    query: Optional[str] = None,
-    models: Optional[List[str]] = None,
-    include_fields: bool = False,
-    refresh: bool = False,
-    limit: int = 50,
-    instance: Optional[str] = None,
+    query: Annotated[
+        Optional[str], Field(description="Optional text used to filter catalog models.")
+    ] = None,
+    models: Annotated[
+        Optional[List[str]],
+        Field(description="Optional technical model names to include in the catalog."),
+    ] = None,
+    include_fields: Annotated[
+        bool, Field(description="Whether to include field metadata for each model.")
+    ] = False,
+    refresh: Annotated[
+        bool, Field(description="Whether to bypass and refresh the cached catalog.")
+    ] = False,
+    limit: Annotated[
+        int, Field(description="Maximum catalog models to return; capped at 500.")
+    ] = 50,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> SchemaCatalogResponse:
     """Return a cached catalog of model names, labels, and optional fields."""
     try:
@@ -756,10 +778,17 @@ def search_employee(
 )
 def search_holidays(
     ctx: Context,
-    start_date: str,
-    end_date: str,
-    employee_id: Optional[int] = None,
-    instance: Optional[str] = None,
+    start_date: Annotated[
+        str, Field(description="Start date in YYYY-MM-DD format.")
+    ],
+    end_date: Annotated[str, Field(description="End date in YYYY-MM-DD format.")],
+    employee_id: Annotated[
+        Optional[int], Field(description="Optional employee ID used to filter holidays.")
+    ] = None,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> SearchHolidaysResponse:
     """
     Searches for holidays within a specified date range.

--- a/src/odoo_mcp/tools_write.py
+++ b/src/odoo_mcp/tools_write.py
@@ -12,9 +12,10 @@ import os
 import stat
 import xmlrpc.client
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.server.fastmcp import Context
+from pydantic import Field
 
 from .agent_tools import (
     build_approval_token,
@@ -647,11 +648,27 @@ def chatter_post(
 )
 def execute_method(
     ctx: Context,
-    model: str,
-    method: str,
-    args: Optional[List[Any]] = None,
-    kwargs: Optional[Dict[str, Any]] = None,
-    instance: Optional[str] = None,
+    model: Annotated[
+        str, Field(description="Technical Odoo model name, for example 'res.partner'.")
+    ],
+    method: Annotated[
+        str,
+        Field(
+            description=(
+                "Odoo model method to call; direct create, write, and unlink are blocked."
+            )
+        ),
+    ],
+    args: Annotated[
+        Optional[List[Any]], Field(description="Optional positional method arguments.")
+    ] = None,
+    kwargs: Annotated[
+        Optional[Dict[str, Any]], Field(description="Optional keyword method arguments.")
+    ] = None,
+    instance: Annotated[
+        Optional[str],
+        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+    ] = None,
 ) -> Dict[str, Any]:
     """
     Execute a custom method on an Odoo model

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -19,6 +19,67 @@ TYPED_READ_TOOLS = {
     "aggregate_records": "rows",
 }
 
+DESCRIBED_INPUT_TOOLS = {
+    "accounting_health_across_instances": {
+        "direction",
+        "as_of",
+        "top_partners",
+        "instances",
+    },
+    "execute_method": {"model", "method", "args", "kwargs", "instance"},
+    "get_odoo_profile": {"include_modules", "module_limit", "instance"},
+    "diagnose_access": {
+        "model",
+        "operation",
+        "domain",
+        "record_ids",
+        "expected_count",
+        "include_rules",
+        "observed_error",
+        "limit",
+        "instance",
+    },
+    "schema_catalog": {
+        "query",
+        "models",
+        "include_fields",
+        "refresh",
+        "limit",
+        "instance",
+    },
+    "search_holidays": {"start_date", "end_date", "employee_id", "instance"},
+    "business_pack_report": {"pack", "use_live_metadata", "instance"},
+    "diagnose_odoo_call": {
+        "model",
+        "method",
+        "args",
+        "kwargs",
+        "transport",
+        "target_version",
+        "observed_error",
+        "include_debug",
+        "metadata",
+        "use_live_metadata",
+    },
+    "receivable_payable_aging": {
+        "direction",
+        "as_of",
+        "top_partners",
+        "limit",
+        "instance",
+    },
+    "upgrade_risk_report": {
+        "source_version",
+        "target_version",
+        "modules",
+        "methods",
+        "source_findings",
+        "observed_errors",
+        "use_live_metadata",
+        "include_debug",
+    },
+}
+
 
 def _tools_by_name():
     tools = asyncio.run(server.mcp.list_tools())
@@ -35,6 +96,16 @@ def test_read_tools_expose_typed_output_schemas():
         assert "success" in props, name
         assert "error" in props, name
         assert marker_field in props, (name, sorted(props))
+
+
+def test_target_tools_describe_every_input_parameter_and_hide_context():
+    tools = _tools_by_name()
+    for name, expected_parameters in DESCRIBED_INPUT_TOOLS.items():
+        properties = tools[name].inputSchema.get("properties", {})
+        assert set(properties) == expected_parameters, name
+        assert "ctx" not in properties, name
+        for parameter, schema in properties.items():
+            assert schema.get("description", "").strip(), (name, parameter)
 
 
 def test_envelope_models_accept_success_and_error_shapes():


### PR DESCRIPTION
## Summary

Adds per-parameter descriptions to the generated MCP input schemas for the 10 highest-priority tools listed in #35.

This wraps each non-context parameter with `Annotated[..., Field(description="...")]` so MCP clients and inspectors can show useful `inputSchema.properties[*].description` metadata. This is schema UX metadata only; no runtime behavior, defaults, validation rules, decorators, or write-safety gates were changed.

Closes #35.

## Coverage

- Odoo versions tested: Not applicable as schema metadata only; no live Odoo runtime behavior changed.
- Transports tested: stdio/schema registration via `server.mcp.list_tools()` through the test suite; no transport behavior changed.

## Verification

```bash
uv run python -m pytest tests/test_schemas.py
uv run python -m ruff check .
uv run python -m mypy src
uv run python -m pytest
git diff --check
```

## Results

- `uv run python -m pytest tests/test_schemas.py` - 7 passed
- `uv run python -m ruff check .` - passed
- `uv run python -m mypy src` - passed
- `uv run python -m pytest` - 886 passed, 1 existing warning
- `git diff --check` - passed

`PYTHONPATH=src uv run lint-imports` could not be invoked because `lint-imports` / `import-linter` is not declared in the current project dev dependencies.

## Checklist

- [x] Updated `README.md` / `docs/` when behavior changes - not applicable, schema metadata only
- [x] Updated `CHANGELOG.md` under `## Unreleased` - not applicable, schema metadata only
- [x] No credentials, private database names, or production debug traces in diff or logs
- [x] Write-execution safety gates (`preview_write` → `validate_write` → `execute_approved_write`, `ODOO_MCP_ENABLE_WRITES`) are unchanged, OR the change is accompanied by a security note explaining why

## Notes for reviewers

This PR does not change function bodies, decorators, defaults, validation constraints, or write execution behavior.

`ctx: Context` parameters were intentionally left unannotated and remain absent from generated input schemas.

`pydantic.Field` is already used elsewhere in the source tree and is available transitively through `mcp>=1.27`, so this PR does not add a new direct dependency.