### PR TITLE
Suggest close model names for history lookups

### DIFF
--- a/src/odoo_mcp/agent_tools.py
+++ b/src/odoo_mcp/agent_tools.py
@@ -7,6 +7,7 @@ adapters pass live metadata in when they have it.
 from __future__ import annotations
 
 import ast
+import difflib
 import hashlib
 import json
 import os
@@ -1299,11 +1300,24 @@ def lookup_model_history_report(name: str) -> dict[str, Any]:
                 f"{entry['old_model']} (changed in Odoo {entry['changed_in']})."
             )
     if match_type == "none":
+        model_names = {
+            model_name
+            for entry in entries
+            for model_name in (entry.get("old_model"), entry.get("new_model"))
+            if model_name
+        }
+        suggestions = difflib.get_close_matches(
+            normalized, model_names, n=5, cutoff=0.65
+        )
         guidance.append(
             "No rename history found in the curated catalog. The name may be "
             "current, custom, or missing from the catalog — verify with "
             "list_models or schema_catalog."
         )
+        if suggestions:
+            guidance.append("Did you mean: " + ", ".join(suggestions) + "?")
+    else:
+        suggestions = []
 
     return {
         "success": True,
@@ -1311,6 +1325,7 @@ def lookup_model_history_report(name: str) -> dict[str, Any]:
         "query": name,
         "match_type": match_type,
         "matches": matches,
+        "suggestions": suggestions,
         "guidance": guidance,
         "catalog": {
             "catalog_version": catalog.get("catalog_version"),

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -784,6 +784,12 @@ def test_lookup_model_history_partial_and_no_match():
     assert missing["matches"] == []
     assert any("list_models" in line for line in missing["guidance"])
 
+    typo = agent_tools.lookup_model_history_report("account.invoicee")
+    assert typo["match_type"] == "none"
+    assert typo["matches"] == []
+    assert "account.invoice" in typo["suggestions"]
+    assert any("Did you mean: " in line for line in typo["guidance"])
+
 
 def test_lookup_model_history_rejects_empty_name():
     report = agent_tools.lookup_model_history_report("   ")


### PR DESCRIPTION
## Summary

Fixes #37.

Adds a small fallback to `lookup_model_history` so typoed or abbreviated model names can return likely catalog suggestions after exact and partial matching both fail.

AI-assisted: prepared with Codex and manually reviewed before submission.

## Tests

- `uv run python -m pytest`
- `uv run python -m ruff check .`
- `uv run python -m mypy src`
- `uv run python -m black --check src/odoo_mcp/agent_tools.py tests/test_agent_tools.py`
- `git diff --check`

## Notes

- Uses Python stdlib `difflib`; no new dependency.
- Existing exact and partial matches stay unchanged.
