### PR TITLE
fix: request marshal-safe fields_get attributes in get_model_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ All notable changes to this project will be documented in this file.
   human checkpoints) on top of the MCP tool layer, for Claude Code and other
   skills-compatible agents. Install by copying into `~/.claude/skills/`.
 
+### Fixed
+- `get_model_fields` now requests a bounded, marshal-safe `attributes` list
+  instead of a full `fields_get`. On Odoo 19, a full `fields_get` faults
+  **server-side** for models whose `domain` attribute is `None` (e.g.
+  `product.pricelist`) — Odoo's own XML-RPC layer refuses to marshal its
+  response, which no client flag can fix (complements the client-side
+  `allow_none` fix shipped in 1.1.0). The bounded list covers every attribute
+  the server consumes (`string`, `help`, `type`, `required`, `readonly`,
+  `relation`, `selection`, `store`, `searchable`); an absent attribute reads
+  as `None` via `.get()`, exactly as before. Unblocks `validate_write` on such
+  models (e.g. creating an IQD `product.pricelist`).
+
 ## [1.1.0] - 2026-07-02
 
 Community-roadmap release: the server becomes a platform (plugins), the

--- a/src/odoo_mcp/odoo_client.py
+++ b/src/odoo_mcp/odoo_client.py
@@ -533,6 +533,23 @@ class OdooClient:
             print(f"Error retrieving model info: {str(e)}", file=sys.stderr)
             return {"error": str(e)}
 
+    # fields_get attributes requested by get_model_fields. Bounded on purpose: Odoo 19's XML-RPC
+    # layer fails server-side ("cannot marshal None") on models whose full fields_get contains a
+    # None-valued attribute (e.g. `domain` on product.pricelist), which broke validate_write for
+    # those models. This list covers every attribute the server consumes; a missing attribute reads
+    # as None via .get(), exactly as before.
+    FIELDS_GET_ATTRIBUTES = [
+        "string",
+        "help",
+        "type",
+        "required",
+        "readonly",
+        "relation",
+        "selection",
+        "store",
+        "searchable",
+    ]
+
     def get_model_fields(self, model_name: str) -> dict[str, Any]:
         """
         Get field definitions for a specific model
@@ -550,7 +567,9 @@ class OdooClient:
             'char'
         """
         try:
-            fields = self._execute(model_name, "fields_get")
+            fields = self._execute(
+                model_name, "fields_get", attributes=self.FIELDS_GET_ATTRIBUTES
+            )
             return cast(dict[str, Any], fields)
         except Exception as e:
             print(f"Error retrieving fields: {str(e)}", file=sys.stderr)

--- a/tests/test_odoo_client.py
+++ b/tests/test_odoo_client.py
@@ -153,6 +153,27 @@ def test_client_initialization_enables_allow_none_on_xmlrpc_proxies(
     assert seen == {"common": True, "object": True}
 
 
+def test_get_model_fields_requests_bounded_marshal_safe_attributes(
+    monkeypatch, odoo_client_module
+):
+    # A full fields_get faults SERVER-SIDE on Odoo 19 when an attribute value is None
+    # (e.g. `domain` on product.pricelist): Odoo's own XML-RPC layer cannot marshal it.
+    # get_model_fields must therefore request only the attributes the server consumes.
+    client, calls = build_client(monkeypatch, odoo_client_module)
+
+    client.get_model_fields("res.partner")
+
+    method_call = calls[-1]
+    assert method_call[0] == "execute_kw"
+    args = method_call[1]
+    assert args[3] == "res.partner"
+    assert args[4] == "fields_get"
+    assert args[6] == {
+        "attributes": odoo_client_module.OdooClient.FIELDS_GET_ATTRIBUTES
+    }
+    assert "domain" not in odoo_client_module.OdooClient.FIELDS_GET_ATTRIBUTES
+
+
 def test_execute_method_passes_database_credentials_model_method_args_and_kwargs(
     monkeypatch, odoo_client_module
 ):


### PR DESCRIPTION
## Summary

Follow-up to #25. That fix (`allow_none=True` on the client's `ServerProxy`) was necessary but **not sufficient** for the `cannot marshal None unless allow_none is enabled` failures: on Odoo 19, a bare `fields_get` call can fail **server-side** — Odoo's own XML-RPC marshaller rejects the response because some field attributes (e.g. `domain`) come back as `None`. The client never gets a payload to be lenient about; the server faults first.

## Root cause

`get_model_fields` calls `fields_get` with no `attributes` argument, so Odoo returns every attribute for every field — including `None`-valued ones that its own XML-RPC layer cannot marshal on some models (live repro: `product.pricelist` on Odoo 19 — full `fields_get` -> `Fault`; bounded attributes -> 39 fields returned cleanly).

## Fix

`get_model_fields` now requests a bounded, marshal-safe `attributes` list (`FIELDS_GET_ATTRIBUTES`) covering everything the server's metadata consumers actually use, while excluding the attributes observed to carry `None` over XML-RPC. Behavior is unchanged for models that worked before; previously-faulting models now return metadata.

## Testing

- New unit test asserts `fields_get` is invoked with the bounded attribute list.
- Live verification on Odoo 19: `product.pricelist` metadata reads succeed (previously faulted), IQD pricelist creation flow unblocked end-to-end.
