### PR TITLE
Fix: canonical payload hashing is unstable across int/float JSON transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ All notable changes to this project will be documented in this file.
   skills-compatible agents. Install by copying into `~/.claude/skills/`.
 
 ### Fixed
+- **Write-approval token instability across int/float JSON transports** —
+  `canonical_json` (`agent_tools.py`) now normalizes integral floats (`1.0`)
+  to `int` (`1`) before hashing, recursively across dicts/lists. Previously,
+  a numeric value that round-tripped through a JSON transport layer where
+  `1` and `1.0` are the same value (common in JS/TS clients and gateways)
+  could change the SHA-256 approval token between `preview_write`/
+  `validate_write` and `execute_approved_write`, causing intermittent
+  `"approval token does not match the canonical payload"` failures on
+  otherwise-valid, unchanged payloads — most visible with "round" numeric
+  field values (e.g. `unit_amount: 1.0` on `account.analytic.line`).
+  Booleans are left untouched. No change to already-issued tokens for
+  payloads that only ever contained plain ints.
 - `get_model_fields` now requests a bounded, marshal-safe `attributes` list
   instead of a full `fields_get`. On Odoo 19, a full `fields_get` faults
   **server-side** for models whose `domain` attribute is `None` (e.g.

--- a/src/odoo_mcp/agent_tools.py
+++ b/src/odoo_mcp/agent_tools.py
@@ -72,9 +72,31 @@ BUSINESS_PACKS: dict[str, dict[str, Any]] = {
 }
 
 
+def _normalize_numbers(value: Any) -> Any:
+    """Recursively collapse integral floats (``1.0``) to ``int`` (``1``).
+
+    JSON has one number type; Python's ``json`` module does not. A payload
+    that crosses a JS/TS transport layer and back can turn an int into a
+    float with the same numeric value (``1`` -> ``1.0``), which changes
+    ``canonical_json``'s output and therefore the SHA-256 approval token —
+    even though the value is unchanged from a business standpoint. Booleans
+    are left untouched despite being an ``int`` subclass in Python.
+    """
+    if isinstance(value, dict):
+        return {key: _normalize_numbers(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_numbers(item) for item in value]
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
 def canonical_json(value: Any) -> str:
     """Return a stable JSON representation for hashing and comparisons."""
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    normalized = _normalize_numbers(value)
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
 
 
 def build_approval_token(payload: dict[str, Any]) -> str:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -253,6 +253,72 @@ def test_verify_write_approval_returns_true_for_matching_token():
     assert is_valid is True
 
 
+# ----- canonical_json / build_approval_token int/float stability -----------
+
+
+def test_canonical_json_treats_integral_float_same_as_int():
+    assert agent_tools.canonical_json({"unit_amount": 1.0}) == agent_tools.canonical_json(
+        {"unit_amount": 1}
+    )
+
+
+def test_canonical_json_normalizes_integral_floats_in_nested_structures():
+    payload = {"values_list": [{"amount": 2.0, "ids": [3.0, 4]}], "record_ids": [5.0]}
+    assert agent_tools.canonical_json(payload) == agent_tools.canonical_json(
+        {"values_list": [{"amount": 2, "ids": [3, 4]}], "record_ids": [5]}
+    )
+
+
+def test_canonical_json_preserves_non_integral_floats():
+    assert agent_tools.canonical_json({"unit_amount": 1.0167}) != agent_tools.canonical_json(
+        {"unit_amount": 1}
+    )
+
+
+def test_canonical_json_does_not_coerce_booleans_to_numbers():
+    assert agent_tools.canonical_json({"active": True}) != agent_tools.canonical_json(
+        {"active": 1}
+    )
+
+
+def test_build_approval_token_matches_across_int_and_float_representation():
+    token_with_float = agent_tools.build_approval_token({"unit_amount": 1.0})
+    token_with_int = agent_tools.build_approval_token({"unit_amount": 1})
+    assert token_with_float == token_with_int
+
+
+def test_verify_write_approval_accepts_token_built_with_integral_float():
+    canonical = {
+        "model": "account.analytic.line",
+        "operation": "create",
+        "record_ids": [],
+        "values": {"unit_amount": 1.0},
+        "context": {},
+        "instance": "default",
+    }
+    # Simulate preview_write hashing a float that arrived as an int through
+    # a re-verification pass (e.g. a JSON transport that dropped the ".0").
+    token = agent_tools.build_approval_token(canonical)
+    reverified = {**canonical, "values": {"unit_amount": 1}, "token": token}
+    is_valid, _ = agent_tools.verify_write_approval(reverified)
+    assert is_valid is True
+
+
+def test_verify_write_approval_accepts_token_built_with_int_reverified_as_float():
+    canonical = {
+        "model": "account.analytic.line",
+        "operation": "create",
+        "record_ids": [],
+        "values": {"unit_amount": 1},
+        "context": {},
+        "instance": "default",
+    }
+    token = agent_tools.build_approval_token(canonical)
+    reverified = {**canonical, "values": {"unit_amount": 1.0}, "token": token}
+    is_valid, _ = agent_tools.verify_write_approval(reverified)
+    assert is_valid is True
+
+
 # ----- validate_write_report metadata branches ------------------------------
 
 


### PR DESCRIPTION
## Problem

The gated write flow (`preview_write` → `validate_write` → `execute_approved_write`)
fails **intermittently** on valid, unchanged payloads with:

```
approval token does not match the canonical payload; re-run preview_write and validate_write
```

Root cause is in `canonical_json` (`src/odoo_mcp/agent_tools.py`), which feeds
`build_approval_token`:

```python
def canonical_json(value: Any) -> str:
    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
```

JSON has a single number type; Python's `json` module does not. `json.dumps(1.0)`
is `"1.0"` while `json.dumps(1)` is `"1"`, so an integral float and an int with the
**same business value** hash to different SHA-256 tokens. Any MCP client or gateway
that normalizes `1.0` to `1` (common in JS/TS transports) can change a numeric
field's representation *between* the moment `preview_write`/`validate_write` hash the
payload and the moment `execute_approved_write` re-hashes it — breaking the token
comparison even though nothing about the payload changed.

The failure is non-deterministic because it depends on whether a given number
survived the round-trip as `1.0` or `1`. It shows up most on "round" values.

## Minimal reproduction

Creating timesheet lines (`account.analytic.line`) against an Odoo 19 instance
(External JSON-2 transport):

| `unit_amount` | Result |
|---|---|
| `1.0` (integral) | ❌ token mismatch at `execute_approved_write` |
| `1.5` (non-integral) | ✅ succeeds |
| `2.0` (integral) | ❌ token mismatch |

Same payloads, differing only by whether the numeric value is integral. Replacing a
round value (`1.0`) with a non-round one (`1.0167`) makes the error disappear
consistently — the tell-tale sign of int/float ambiguity rather than a logic bug.

## Fix

Normalize integral floats to `int` recursively before serializing for the hash, so
`1.0` and `1` produce the same canonical string and therefore the same token.
Booleans (an `int` subclass in Python) are explicitly left untouched; non-integral
floats are unaffected.

```python
def _normalize_numbers(value: Any) -> Any:
    if isinstance(value, dict):
        return {k: _normalize_numbers(v) for k, v in value.items()}
    if isinstance(value, (list, tuple)):
        return [_normalize_numbers(v) for v in value]
    if isinstance(value, bool):
        return value
    if isinstance(value, float) and value.is_integer():
        return int(value)
    return value
```

This changes only the hashing normalization; the values sent to Odoo are untouched.
Tokens for payloads that only ever contained plain ints are unchanged, so this is
backward-compatible for the common case.

## Tests

Added to `tests/test_agent_tools.py` (all green; full suite `906 passed` via
`uv run python -m pytest -m "not yolo and not mcp"`):

- `test_canonical_json_treats_integral_float_same_as_int`
- `test_canonical_json_normalizes_integral_floats_in_nested_structures`
- `test_canonical_json_preserves_non_integral_floats`
- `test_canonical_json_does_not_coerce_booleans_to_numbers`
- `test_build_approval_token_matches_across_int_and_float_representation`
- `test_verify_write_approval_accepts_token_built_with_integral_float`
- `test_verify_write_approval_accepts_token_built_with_int_reverified_as_float`

The last two reproduce the exact bug: a token built from `{"unit_amount": 1.0}` is
re-verified against `{"unit_amount": 1}` (and vice-versa) and must validate.

## Notes

- `CHANGELOG.md` updated under Unreleased.
- Verified end-to-end against a live Odoo 19 (JSON-2) instance: the three timesheet
  lines above (`1.0`, `1.5`, `2.0`) all succeed after the fix, where `1.0`/`2.0`
  previously failed on the published build. Happy to re-run against the
  `scripts/odoo_compose_smoke.py` 16/17/18/19 matrix if useful.
- A separate, larger concern — the in-process `write_approvals` store not being
  shared across workers (a second, independent cause of
  `"approval token has not been validated in this server session"` under
  multi-worker deployments) — is intentionally **not** in this PR. I can open a
  separate issue with two proposals (self-contained HMAC token; shared store with
  in-memory fallback) if you'd like to discuss it.
