### PR TITLE
feat(schemas): add typed output schemas for remaining tool groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,15 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
-# tools_read annotates protocol-level response models (typed MCP outputSchema)
+# Tool modules annotate protocol-level response models (typed MCP outputSchema)
 # while the functions keep returning the plain-dict envelope FastMCP validates
 # at the MCP layer; the runtime dict/model mismatch is deliberate.
 [[tool.mypy.overrides]]
-module = "odoo_mcp.tools_read"
+module = [
+    "odoo_mcp.tools_read",
+    "odoo_mcp.tools_accounting",
+    "odoo_mcp.tools_async",
+    "odoo_mcp.tools_cross_instance",
+    "odoo_mcp.tools_knowledge",
+]
 disable_error_code = ["return-value"]

--- a/src/odoo_mcp/schemas.py
+++ b/src/odoo_mcp/schemas.py
@@ -142,3 +142,105 @@ class AggregateRecordsResponse(ToolResponse):
     rows: Optional[List[Dict[str, Any]]] = Field(
         default=None, description="Aggregated group rows."
     )
+
+
+class IndexKnowledgeResponse(ToolResponse):
+    instance: Optional[str] = None
+    model: Optional[str] = None
+    indexed: Optional[int] = None
+    skipped_over_budget: Optional[int] = None
+    documents_in_index: Optional[int] = None
+    max_documents: Optional[int] = None
+    fetched: Optional[int] = None
+    indexed_fields: Optional[Any] = Field(
+        default=None, description="Explicit field list or 'smart selection'."
+    )
+    redacted_fields: Optional[List[str]] = None
+
+
+class SearchKnowledgeResponse(ToolResponse):
+    instance: Optional[str] = None
+    model: Optional[str] = None
+    query: Optional[str] = None
+    results: Optional[List[Dict[str, Any]]] = Field(
+        default=None, description="BM25-ranked snippets from the local index."
+    )
+
+
+class KnowledgeStatsResponse(ToolResponse):
+    indexes: Optional[List[Dict[str, Any]]] = None
+    total_documents: Optional[int] = None
+    max_documents: Optional[int] = None
+
+
+class ReceivablePayableAgingResponse(ToolResponse):
+    direction: Optional[str] = None
+    as_of: Optional[str] = None
+    buckets: Optional[Dict[str, Any]] = None
+    total_outstanding: Optional[float] = None
+    partner_count: Optional[int] = None
+    partners: Optional[List[Dict[str, Any]]] = None
+    line_count: Optional[int] = None
+    skipped_lines: Optional[int] = None
+    truncated: Optional[str] = None
+
+
+class AccountingHealthSummaryResponse(ToolResponse):
+    open_receivable_items: Optional[int] = None
+    open_payable_items: Optional[int] = None
+    draft_invoices: Optional[int] = None
+
+
+class AsyncTaskResponse(ToolResponse):
+    task_id: Optional[str] = None
+    name: Optional[str] = None
+    status: Optional[str] = None
+    created_at: Optional[float] = None
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    result: Optional[Dict[str, Any]] = None
+    note: Optional[str] = None
+
+
+class ListAsyncTasksResponse(ToolResponse):
+    tasks: Optional[List[Dict[str, Any]]] = None
+
+
+class SearchAcrossInstancesResponse(ToolResponse):
+    model: Optional[str] = None
+    merged: Optional[List[Dict[str, Any]]] = None
+    merged_count: Optional[int] = None
+    instances_queried: Optional[List[str]] = None
+    instance_count: Optional[int] = None
+    errors: Optional[Dict[str, str]] = None
+    results: Optional[Dict[str, Any]] = None
+    skipped_opt_out: Optional[List[str]] = None
+    unknown_instances: Optional[List[str]] = None
+    elapsed_ms: Optional[float] = None
+
+
+class AggregateAcrossInstancesResponse(ToolResponse):
+    model: Optional[str] = None
+    combined_count: Optional[int] = None
+    combined_measures: Optional[Dict[str, float]] = None
+    instances_queried: Optional[List[str]] = None
+    instance_count: Optional[int] = None
+    errors: Optional[Dict[str, str]] = None
+    results: Optional[Dict[str, Any]] = None
+    skipped_opt_out: Optional[List[str]] = None
+    unknown_instances: Optional[List[str]] = None
+    elapsed_ms: Optional[float] = None
+
+
+class AccountingHealthAcrossInstancesResponse(ToolResponse):
+    direction: Optional[str] = None
+    as_of: Optional[str] = None
+    combined_buckets: Optional[Dict[str, float]] = None
+    combined_total_outstanding: Optional[float] = None
+    instances_queried: Optional[List[str]] = None
+    instance_count: Optional[int] = None
+    errors: Optional[Dict[str, str]] = None
+    results: Optional[Dict[str, Any]] = None
+    skipped_opt_out: Optional[List[str]] = None
+    unknown_instances: Optional[List[str]] = None
+    elapsed_ms: Optional[float] = None

--- a/src/odoo_mcp/tools_accounting.py
+++ b/src/odoo_mcp/tools_accounting.py
@@ -13,6 +13,10 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
+from .schemas import (
+    AccountingHealthSummaryResponse,
+    ReceivablePayableAgingResponse,
+)
 from .accounting_tools import (
     MAX_AGING_LINES,
     build_aging_report,
@@ -33,9 +37,7 @@ def build_direction_aging(
 ) -> Dict[str, Any]:
     """Fetch open items and bucket them (shared by sync and async paths)."""
     lines = fetch_aging_lines(odoo, direction, limit=limit)
-    report = build_aging_report(
-        lines, direction, as_of, top_partners=top_partners
-    )
+    report = build_aging_report(lines, direction, as_of, top_partners=top_partners)
     if len(lines) >= limit:
         report["truncated"] = (
             f"Line fetch hit the {limit} cap; totals may be partial. "
@@ -66,9 +68,11 @@ def receivable_payable_aging(
     ] = MAX_AGING_LINES,
     instance: Annotated[
         Optional[str],
-        Field(description="Optional configured Odoo instance name; uses the default if omitted."),
+        Field(
+            description="Optional configured Odoo instance name; uses the default if omitted."
+        ),
     ] = None,
-) -> Dict[str, Any]:
+) -> ReceivablePayableAgingResponse:
     """Bucket open posted items (not due / 1-30 / 31-60 / 61-90 / 90+ days).
 
     direction: "receivable" (customers owing you) or "payable" (you owing
@@ -104,7 +108,7 @@ def receivable_payable_aging(
 def accounting_health_summary(
     ctx: Context,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> AccountingHealthSummaryResponse:
     """Quick accounting posture: open AR/AP item counts plus draft invoices."""
     try:
         _, odoo = _resolve_odoo(ctx, instance)

--- a/src/odoo_mcp/tools_async.py
+++ b/src/odoo_mcp/tools_async.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, Optional
 
 from mcp.server.fastmcp import Context
 
+from .schemas import AsyncTaskResponse, ListAsyncTasksResponse
 from .accounting_tools import MAX_AGING_LINES, parse_as_of
 from .agent_tools import scan_addons_source_report
 from .server_core import (
@@ -159,7 +160,7 @@ def submit_async_task(
     operation: str,
     params: Optional[Dict[str, Any]] = None,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> AsyncTaskResponse:
     """Submit a background task; poll with get_async_task.
 
     Allowlisted operations: scan_addons_source (params: addons_paths,
@@ -198,7 +199,7 @@ def submit_async_task(
     annotations=PREVIEW_TOOL,
     structured_output=True,
 )
-def get_async_task(task_id: str) -> Dict[str, Any]:
+def get_async_task(task_id: str) -> AsyncTaskResponse:
     """Return task status; includes the result once status is succeeded."""
     try:
         return {"tool": "get_async_task", **get_task_manager().status(task_id)}
@@ -211,7 +212,7 @@ def get_async_task(task_id: str) -> Dict[str, Any]:
     annotations=PREVIEW_TOOL,
     structured_output=True,
 )
-def cancel_async_task(task_id: str) -> Dict[str, Any]:
+def cancel_async_task(task_id: str) -> AsyncTaskResponse:
     """Cancel a task: pending tasks never start; running ones are discarded."""
     try:
         return {"tool": "cancel_async_task", **get_task_manager().cancel(task_id)}
@@ -224,7 +225,7 @@ def cancel_async_task(task_id: str) -> Dict[str, Any]:
     annotations=PREVIEW_TOOL,
     structured_output=True,
 )
-def list_async_tasks() -> Dict[str, Any]:
+def list_async_tasks() -> ListAsyncTasksResponse:
     """List live and recently finished tasks (results omitted; poll by id)."""
     try:
         return {

--- a/src/odoo_mcp/tools_cross_instance.py
+++ b/src/odoo_mcp/tools_cross_instance.py
@@ -34,6 +34,11 @@ from .cross_instance import (
 )
 from .field_policy import get_field_policy
 from .rate_limit import check_rate
+from .schemas import (
+    AccountingHealthAcrossInstancesResponse,
+    AggregateAcrossInstancesResponse,
+    SearchAcrossInstancesResponse,
+)
 from .server_core import READ_ONLY_TOOL, mcp
 from .tool_helpers import (
     clamp_limit,
@@ -193,9 +198,7 @@ def run_accounting_health_across(
         name, client = app_context.get_client(instance)
         _guard_rate(name, "accounting_health_across_instances")
         lines = fetch_aging_lines(client, direction)
-        return build_aging_report(
-            lines, direction, as_of, top_partners=top_partners
-        )
+        return build_aging_report(lines, direction, as_of, top_partners=top_partners)
 
     results, errors = _fan_out(selection.selected, worker)
     combined = combine_bucket_reports(results)
@@ -229,7 +232,7 @@ def search_across_instances(
     fields: Optional[List[str]] = None,
     limit_per_instance: int = DEFAULT_LIMIT_PER_INSTANCE,
     instances: Optional[Any] = None,
-) -> Dict[str, Any]:
+) -> SearchAcrossInstancesResponse:
     """Run one search across many instances; rows are tagged with `_instance`.
 
     `instances`: omit or "all" for every opted-in instance, a list of names,
@@ -269,7 +272,7 @@ def aggregate_across_instances(
     measures: Optional[List[str]] = None,
     domain: Optional[Any] = None,
     instances: Optional[Any] = None,
-) -> Dict[str, Any]:
+) -> AggregateAcrossInstancesResponse:
     """Group/aggregate per instance plus additive grand totals across them.
 
     `measures` are "field:agg" strings. Combined totals sum additive measures
@@ -314,13 +317,18 @@ def accounting_health_across_instances(
         Field(description="Optional ISO date used as the aging reference date."),
     ] = None,
     top_partners: Annotated[
-        int, Field(description="Maximum top partners to include in each aging report; capped at 100.")
+        int,
+        Field(
+            description="Maximum top partners to include in each aging report; capped at 100."
+        ),
     ] = 10,
     instances: Annotated[
         Optional[Any],
-        Field(description="Optional instance selector; defaults to all eligible instances."),
+        Field(
+            description="Optional instance selector; defaults to all eligible instances."
+        ),
     ] = None,
-) -> Dict[str, Any]:
+) -> AccountingHealthAcrossInstancesResponse:
     """Aged receivable/payable across every client DB, with combined buckets.
 
     The anti-Peliqan flagship: ask "which clients have AR over 90 days?" once

--- a/src/odoo_mcp/tools_knowledge.py
+++ b/src/odoo_mcp/tools_knowledge.py
@@ -13,6 +13,11 @@ from mcp.server.fastmcp import Context
 
 from .field_policy import get_field_policy
 from .knowledge_index import get_knowledge_store
+from .schemas import (
+    IndexKnowledgeResponse,
+    KnowledgeStatsResponse,
+    SearchKnowledgeResponse,
+)
 from .server_core import (
     PREVIEW_TOOL,
     READ_ONLY_TOOL,
@@ -71,7 +76,7 @@ def index_knowledge(
     limit: int = 500,
     replace: bool = False,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> IndexKnowledgeResponse:
     """Index records for free-text relevance search without further RPC calls.
 
     Data stays in process memory on this machine. ``fields=None`` uses the
@@ -106,7 +111,7 @@ def search_knowledge(
     model: str,
     limit: int = 5,
     instance: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> SearchKnowledgeResponse:
     """Rank indexed records against a free-text query (accent-insensitive).
 
     Purely local: never contacts Odoo. Run index_knowledge for the model
@@ -116,9 +121,7 @@ def search_knowledge(
         validate_model_name(model)
         limit = clamp_limit(limit, maximum=50)
         instance_name = str(_srv().resolve_instance_name(instance))
-        result = get_knowledge_store().search(
-            instance_name, model, query, limit=limit
-        )
+        result = get_knowledge_store().search(instance_name, model, query, limit=limit)
         return {"tool": "search_knowledge", **result}
     except Exception as e:
         return {"success": False, "tool": "search_knowledge", "error": str(e)}
@@ -129,7 +132,7 @@ def search_knowledge(
     annotations=PREVIEW_TOOL,
     structured_output=True,
 )
-def knowledge_stats() -> Dict[str, Any]:
+def knowledge_stats() -> KnowledgeStatsResponse:
     """List per-model index sizes, total documents, and the configured cap."""
     try:
         return {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -80,6 +80,21 @@ DESCRIBED_INPUT_TOOLS = {
     },
 }
 
+TYPED_DOMAIN_TOOLS = {
+    "index_knowledge": "indexed",
+    "search_knowledge": "results",
+    "knowledge_stats": "indexes",
+    "receivable_payable_aging": "buckets",
+    "accounting_health_summary": "open_receivable_items",
+    "submit_async_task": "task_id",
+    "get_async_task": "task_id",
+    "cancel_async_task": "task_id",
+    "list_async_tasks": "tasks",
+    "search_across_instances": "merged",
+    "aggregate_across_instances": "combined_measures",
+    "accounting_health_across_instances": "combined_buckets",
+}
+
 
 def _tools_by_name():
     tools = asyncio.run(server.mcp.list_tools())
@@ -108,6 +123,17 @@ def test_target_tools_describe_every_input_parameter_and_hide_context():
             assert schema.get("description", "").strip(), (name, parameter)
 
 
+def test_domain_tools_expose_typed_output_schemas():
+    tools = _tools_by_name()
+    for name, marker_field in TYPED_DOMAIN_TOOLS.items():
+        schema = tools[name].outputSchema
+        assert schema is not None, name
+        props = schema.get("properties", {})
+        assert "success" in props, name
+        assert "error" in props, name
+        assert marker_field in props, (name, sorted(props))
+
+
 def test_envelope_models_accept_success_and_error_shapes():
     ok = schemas.SearchRecordsResponse.model_validate(
         {
@@ -131,6 +157,29 @@ def test_envelope_models_accept_success_and_error_shapes():
     assert extra.success is False
 
 
+def test_accounting_health_schema_accepts_runtime_payload():
+    response = schemas.AccountingHealthSummaryResponse.model_validate(
+        {
+            "success": True,
+            "open_receivable_items": 4,
+            "open_payable_items": 3,
+            "draft_invoices": 2,
+        }
+    )
+    assert response.open_receivable_items == 4
+    assert response.open_payable_items == 3
+    assert response.draft_invoices == 2
+
+
+def test_aging_schema_advertises_runtime_payload_fields():
+    properties = schemas.ReceivablePayableAgingResponse.model_json_schema()[
+        "properties"
+    ]
+    assert {"partners", "line_count", "skipped_lines"} <= properties.keys()
+    assert "top_partners" not in properties
+    assert "currency" not in properties
+
+
 def test_load_server_instructions_default(monkeypatch):
     monkeypatch.delenv("ODOO_MCP_INSTRUCTIONS_FILE", raising=False)
     assert (
@@ -149,9 +198,7 @@ def test_load_server_instructions_appends_file(tmp_path, monkeypatch):
 
 
 def test_load_server_instructions_unreadable_fails_closed(monkeypatch, tmp_path):
-    monkeypatch.setenv(
-        "ODOO_MCP_INSTRUCTIONS_FILE", str(tmp_path / "missing.txt")
-    )
+    monkeypatch.setenv("ODOO_MCP_INSTRUCTIONS_FILE", str(tmp_path / "missing.txt"))
     with pytest.raises(ValueError, match="unreadable"):
         server_core.load_server_instructions()
 
@@ -161,6 +208,9 @@ def test_load_server_instructions_truncates(monkeypatch, tmp_path):
     path.write_text("x" * (server_core.MAX_INSTRUCTIONS_CHARS + 500), encoding="utf-8")
     monkeypatch.setenv("ODOO_MCP_INSTRUCTIONS_FILE", str(path))
     text = server_core.load_server_instructions()
-    assert len(text) <= server_core.MAX_INSTRUCTIONS_CHARS + len(
-        server_core.DEFAULT_SERVER_INSTRUCTIONS
-    ) + 2
+    assert (
+        len(text)
+        <= server_core.MAX_INSTRUCTIONS_CHARS
+        + len(server_core.DEFAULT_SERVER_INSTRUCTIONS)
+        + 2
+    )


### PR DESCRIPTION
## Summary

- add typed response models for the remaining knowledge, accounting, async, and cross-instance tools
- annotate those 12 tool functions so FastMCP exposes structured `outputSchema` fields instead of generic object wrappers
- preserve the latest input parameter descriptions while extending schema regression coverage

Closes #30

## Testing

- `uv run --frozen python -m pytest` (912 passed)
- `uv run --frozen python -m ruff check .`
- `uv run --frozen python -m mypy src`
- `uv run --frozen black --check src/odoo_mcp/schemas.py src/odoo_mcp/tools_accounting.py src/odoo_mcp/tools_async.py src/odoo_mcp/tools_cross_instance.py src/odoo_mcp/tools_knowledge.py tests/test_schemas.py`
- `uvx --from import-linter --with-editable . lint-imports`
- `git diff --check`
