### PR TITLE
fix(chatter): let callers post real HTML via message_post(body_is_html=)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **HTML chatter bodies arrived as visible tags.** A `str` body handed to
+  `message_post` is escaped by Odoo — only a `markupsafe.Markup` survives, and
+  RPC cannot carry one, so markup reached the chatter as literal tags. Odoo 17
+  added `message_post(body_is_html=...)` for exactly this case; `chatter_post`
+  now has a `body_is_html` parameter that forwards it on 17+ and omits it on
+  16, which stores bodies verbatim anyway. Opt-in rather than auto-detected:
+  prose such as `send to <a.schmidt@example.com>` is not distinguishable from
+  markup, and guessing wrong drops the text when Odoo renders the field. A body
+  that looks like markup without the flag returns an advisory warning and is
+  posted unchanged. The flag is part of the canonical payload, so a post
+  previewed as plain text cannot be executed as markup.
+
 ## [1.3.0] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Once configured (see [Setup](#setup)), ask your agent things like:
 | Streamable HTTP | Local HTTP/SSE support for clients that do not use stdio. |
 | Smart field selection | `search_records` and `read_record` curate business-relevant fields when no `fields` argument is supplied — drops audit, message, binary, and unstored compute noise. Pass `fields=["*"]` to opt out. |
 | Server-side aggregation | `aggregate_records` pushes groupby/sum/count/avg into Postgres via `formatted_read_group` (Odoo 19+) or `read_group` (16-18). |
-| Chatter integration | `chatter_post` adds messages to any `mail.thread` record under the same approval-token gate as writes — or directly via `MCP_CHATTER_DIRECT=1`. |
+| Chatter integration | `chatter_post` adds messages to any `mail.thread` record under the same approval-token gate as writes — or directly via `MCP_CHATTER_DIRECT=1`. Pass `body_is_html=true` for a formatted body (Odoo 17+). |
 | Locale plumbing | `ODOO_LOCALE` injects `context.lang` automatically on every Odoo call (caller can override). |
 | Structured logging | JSON formatter and rotating file handler via `ODOO_MCP_LOG_LEVEL`, `ODOO_MCP_LOG_JSON`, `ODOO_MCP_LOG_FILE`. |
 | Safe writes | Direct `create`, `write`, and `unlink` are blocked; approved writes require live metadata, a same-session token, explicit confirmation, and an env gate. |
@@ -382,7 +382,7 @@ odoo-mcp --health
 | `validate_write` | Validate a write payload against trusted live `fields_get` metadata. |
 | `execute_approved_write` | Execute only a same-session, live-validated, confirmed write when `ODOO_MCP_ENABLE_WRITES=1`. |
 | `execute_method` | Execute a reviewed model method. Direct `create`, `write`, and `unlink` are blocked. Side-effect methods require an exact allowlist or `ODOO_MCP_ALLOW_UNKNOWN_METHODS=1`. |
-| `chatter_post` | Post a chatter message on a `mail.thread` record. Default mode requires the approval-token preview/execute flow. |
+| `chatter_post` | Post a chatter message on a `mail.thread` record. Default mode requires the approval-token preview/execute flow. `body_is_html=true` posts the body as markup instead of plain text. |
 
 ### Diagnose (3)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,6 +63,7 @@ record rule (Odoo masks unauthorized IDs as missing).
 | Agent loops `read_record` | `health_check` → `runtime.n_plus_one.hot_models` flags it; batch with `search_records` and an `["id", "in", [...]]` domain. |
 | Intermittent `Failed to connect` | Read-only calls retry automatically (`ODOO_MCP_RETRY_ATTEMPTS`, default 2, exponential backoff). Persistent failures: check URL/SSL (`ODOO_VERIFY_SSL`), proxy, and Odoo worker availability. |
 | HTTP transport refuses to start | Non-local binds need `--allow-remote-http` (or `MCP_ALLOW_REMOTE_HTTP=1`) — deliberate, keep it behind your own auth proxy. |
+| HTML in a chatter message shows as `&lt;p&gt;` tags | Odoo escapes any `str` body given to `message_post`; only a `markupsafe.Markup` survives and RPC cannot carry one. Pass `body_is_html=true` to `chatter_post` (Odoo 17+, where the parameter was added for RPC callers). It is opt-in on purpose — prose like `send to <a.schmidt@example.com>` is indistinguishable from markup, so nothing is auto-converted. The same applies to a raw `execute_method(..., "message_post", ...)`: add `body_is_html` to its kwargs yourself. |
 
 ## When opening an issue
 

--- a/src/odoo_mcp/tool_helpers.py
+++ b/src/odoo_mcp/tool_helpers.py
@@ -324,3 +324,25 @@ def normalize_domain_input(domain: Any) -> List[Any]:
             valid_conditions.append(cond)
 
     return valid_conditions
+
+
+# Advisory only: a false positive costs a superfluous warning, never data.
+# Requires a real tag terminator after the name so prose like
+# "<a.schmidt@example.com>" or "<pre-check 2026>" does not match.
+_HTML_TAG_RE = re.compile(
+    r"</?(?:p|br|b|strong|i|em|u|ul|ol|li|a|div|span|h[1-6]|table|thead|tbody"
+    r"|tr|td|th|blockquote|code|pre|hr|img|dl|dt|dd|section|figure)"
+    r"(?:\s[^>]*)?/?>",
+    re.IGNORECASE,
+)
+
+
+def looks_like_html(text: str) -> bool:
+    """True when ``text`` carries markup a chatter body would realistically use.
+
+    Used only to warn a caller who passed markup without ``body_is_html``;
+    nothing is transformed on the strength of this answer, because prose and
+    markup are not reliably distinguishable (``if a<b and b>c`` reads exactly
+    like a tag with attributes).
+    """
+    return bool(_HTML_TAG_RE.search(text or ""))

--- a/src/odoo_mcp/tools_write.py
+++ b/src/odoo_mcp/tools_write.py
@@ -27,7 +27,9 @@ from .agent_tools import (
 from .audit import record_write_event
 from .diagnostics import DESTRUCTIVE_METHODS, classify_method_safety
 from .tool_helpers import (
+    looks_like_html,
     max_attachment_upload_bytes,
+    odoo_major_version,
     normalize_domain_input,
     truthy_env,
     validate_method_name,
@@ -518,6 +520,25 @@ def _execute_approved_write_gated(
         return {"success": False, "tool": "execute_approved_write", "error": str(e)}
 
 
+# Odoo grew ``message_post(body_is_html=...)`` in 17.0 specifically for RPC
+# callers: without it a ``str`` body is escaped (only a ``markupsafe.Markup``
+# passes through, and RPC cannot carry one), so markup would reach the chatter
+# as visible tags. Odoo 16 has no such parameter but also does not escape, so
+# omitting it there is already correct.
+_BODY_IS_HTML_MIN_MAJOR = 17
+
+
+def _supports_body_is_html(odoo: Any) -> bool:
+    """True when this Odoo accepts ``message_post(body_is_html=...)``.
+
+    Version detection is best-effort; an unknown version is treated as
+    supported because every Odoo from 17 on has the parameter and passing it
+    to an older one raises loudly rather than corrupting anything.
+    """
+    major = odoo_major_version(odoo)
+    return major is None or major >= _BODY_IS_HTML_MIN_MAJOR
+
+
 def _build_chatter_payload(
     *,
     model: str,
@@ -528,9 +549,12 @@ def _build_chatter_payload(
     partner_ids: Optional[List[int]],
     attachment_ids: Optional[List[int]],
     instance: str = "default",
+    body_is_html: bool = False,
 ) -> Dict[str, Any]:
     """Build the canonical message_post call payload (deterministic ordering)."""
     kwargs: Dict[str, Any] = {"body": body, "message_type": message_type}
+    if body_is_html:
+        kwargs["body_is_html"] = True
     if subtype_xmlid:
         kwargs["subtype_xmlid"] = subtype_xmlid
     if partner_ids:
@@ -567,6 +591,7 @@ def chatter_post(
     approval: Optional[Dict[str, Any]] = None,
     confirm: bool = False,
     instance: Optional[str] = None,
+    body_is_html: bool = False,
 ) -> Dict[str, Any]:
     """Post a message on the chatter of a mail.thread-derived record.
 
@@ -578,6 +603,16 @@ def chatter_post(
       call without a token.
 
     Allowed ``message_type`` values: ``comment`` (default), ``notification``.
+
+    ``body_is_html``: a body sent over RPC is escaped by Odoo unless this is
+    set, so markup would otherwise arrive as visible tags. It is forwarded to
+    ``message_post`` on Odoo 17+ (which added the parameter for exactly this
+    case) and omitted on 16, which stores bodies verbatim anyway. Left off,
+    the body is treated as plain text — unchanged behaviour — and a warning
+    points this out when the body looks like markup. Deliberately not
+    auto-detected: prose such as ``send to <a.schmidt@example.com>`` is
+    indistinguishable from markup, and guessing wrong silently drops the text
+    when Odoo renders the field.
     """
     try:
         instance_name, odoo = _resolve_odoo(ctx, instance)
@@ -590,6 +625,7 @@ def chatter_post(
         if message_type not in {"comment", "notification"}:
             raise ValueError("message_type must be 'comment' or 'notification'.")
 
+        send_html_flag = body_is_html and _supports_body_is_html(odoo)
         canonical = _build_chatter_payload(
             model=model,
             record_id=record_id,
@@ -599,6 +635,16 @@ def chatter_post(
             partner_ids=partner_ids,
             attachment_ids=attachment_ids,
             instance=instance_name,
+            body_is_html=send_html_flag,
+        )
+        markup_hint = (
+            [
+                "Body looks like HTML but body_is_html is not set, so Odoo will "
+                "escape it and the tags will show as text. Pass "
+                "body_is_html=true to post it as markup."
+            ]
+            if not body_is_html and looks_like_html(body_text)
+            else []
         )
         token = build_approval_token(canonical)
 
@@ -619,7 +665,7 @@ def chatter_post(
                 instance=instance_name,
                 detail="direct mode",
             )
-            return {
+            direct: Dict[str, Any] = {
                 "success": True,
                 "mode": "direct",
                 "model": model,
@@ -627,6 +673,9 @@ def chatter_post(
                 "approval_required": False,
                 "result": result,
             }
+            if markup_hint:
+                direct["warnings"] = markup_hint
+            return direct
 
         if approval is None:
             return {
@@ -638,7 +687,8 @@ def chatter_post(
                 "warnings": [
                     "Preview only. Re-call chatter_post with the returned approval "
                     "and confirm=true to actually post."
-                ],
+                ]
+                + markup_hint,
             }
 
         provided_token = str(approval.get("token", ""))
@@ -666,7 +716,7 @@ def chatter_post(
             instance=instance_name,
             token=provided_token,
         )
-        return {
+        executed: Dict[str, Any] = {
             "success": True,
             "mode": "execute",
             "model": model,
@@ -674,6 +724,9 @@ def chatter_post(
             "approval_required": True,
             "result": result,
         }
+        if markup_hint:
+            executed["warnings"] = markup_hint
+        return executed
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4169,3 +4169,156 @@ def test_legacy_names_remain_importable_from_server():
     ]
     missing = [name for name in legacy_names if not hasattr(server, name)]
     assert missing == []
+
+
+class _VersionedChatterClient(_ChatterClient):
+    """Chatter client that also answers the server-version probe."""
+
+    def __init__(self, major=17, post_result=4242):
+        super().__init__(post_result=post_result)
+        self.major = major
+
+    def get_server_version(self):
+        return {"server_version_info": [self.major, 0, 0, "final", 0, ""]}
+
+
+def test_chatter_post_forwards_body_is_html_on_odoo_17(monkeypatch):
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.setenv("MCP_CHATTER_DIRECT", "1")
+    client = _VersionedChatterClient(major=17)
+
+    result = server.chatter_post(
+        FakeCtx(client),
+        model="res.partner",
+        record_id=7,
+        body="<p>Hello <b>world</b></p>",
+        body_is_html=True,
+    )
+
+    assert result["success"] is True
+    assert client.calls[0][3]["body_is_html"] is True
+    assert client.calls[0][3]["body"] == "<p>Hello <b>world</b></p>"
+    # Explicit flag means no second-guessing the caller.
+    assert "warnings" not in result
+
+
+def test_chatter_post_omits_body_is_html_on_odoo_16(monkeypatch):
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.setenv("MCP_CHATTER_DIRECT", "1")
+    client = _VersionedChatterClient(major=16)
+
+    result = server.chatter_post(
+        FakeCtx(client),
+        model="res.partner",
+        record_id=7,
+        body="<p>Hello</p>",
+        body_is_html=True,
+    )
+
+    assert result["success"] is True
+    # 16 has no such parameter and stores bodies verbatim anyway.
+    assert "body_is_html" not in client.calls[0][3]
+
+
+def test_chatter_post_plain_body_is_unchanged(monkeypatch):
+    """Regression guard: the default path must not gain any new kwarg."""
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.setenv("MCP_CHATTER_DIRECT", "1")
+    client = _ChatterClient()
+
+    result = server.chatter_post(
+        FakeCtx(client),
+        model="res.partner",
+        record_id=7,
+        body="Please forward to <a.schmidt@example.com>",
+    )
+
+    assert result["success"] is True
+    assert set(client.calls[0][3]) == {"body", "message_type"}
+    assert client.calls[0][3]["body"] == "Please forward to <a.schmidt@example.com>"
+    # Prose containing angle brackets must not be mistaken for markup.
+    assert "warnings" not in result
+
+
+def test_chatter_post_warns_when_markup_lacks_the_flag(monkeypatch):
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.setenv("MCP_CHATTER_DIRECT", "1")
+    client = _ChatterClient()
+
+    result = server.chatter_post(
+        FakeCtx(client),
+        model="res.partner",
+        record_id=7,
+        body="<p>Hello</p>",
+    )
+
+    assert result["success"] is True
+    assert any("body_is_html" in w for w in result["warnings"])
+    # Advisory only: the body is posted exactly as given.
+    assert client.calls[0][3]["body"] == "<p>Hello</p>"
+    assert "body_is_html" not in client.calls[0][3]
+
+
+def test_chatter_post_preview_warns_before_posting_markup(monkeypatch):
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.delenv("MCP_CHATTER_DIRECT", raising=False)
+    client = _ChatterClient()
+
+    preview = server.chatter_post(
+        FakeCtx(client),
+        model="res.partner",
+        record_id=7,
+        body="<ul><li>one</li></ul>",
+    )
+
+    assert preview["mode"] == "preview"
+    assert any("body_is_html" in w for w in preview["warnings"])
+    assert client.calls == []
+
+
+def test_chatter_post_token_covers_the_html_flag(monkeypatch):
+    """A preview approved as plain text must not execute as markup."""
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.delenv("MCP_CHATTER_DIRECT", raising=False)
+    client = _VersionedChatterClient(major=17)
+    ctx = FakeCtx(client)
+
+    preview = server.chatter_post(
+        ctx, model="res.partner", record_id=7, body="<p>Hi</p>"
+    )
+    smuggled = server.chatter_post(
+        ctx,
+        model="res.partner",
+        record_id=7,
+        body="<p>Hi</p>",
+        body_is_html=True,
+        approval=preview["approval"],
+        confirm=True,
+    )
+
+    assert smuggled["success"] is False
+    assert "token does not match" in smuggled["error"]
+    assert client.calls == []
+
+
+def test_chatter_post_html_roundtrip_through_the_gate(monkeypatch):
+    server = importlib.import_module("odoo_mcp.server")
+    monkeypatch.delenv("MCP_CHATTER_DIRECT", raising=False)
+    client = _VersionedChatterClient(major=17)
+    ctx = FakeCtx(client)
+
+    preview = server.chatter_post(
+        ctx, model="res.partner", record_id=7, body="<p>Hi</p>", body_is_html=True
+    )
+    approved = server.chatter_post(
+        ctx,
+        model="res.partner",
+        record_id=7,
+        body="<p>Hi</p>",
+        body_is_html=True,
+        approval=preview["approval"],
+        confirm=True,
+    )
+
+    assert approved["mode"] == "execute"
+    assert client.calls[0][3]["body_is_html"] is True

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -525,3 +525,49 @@ class TestNormalizeDomainInput:
             ["name", "=", "'; DROP TABLE--"]
         )
         assert result == [["name", "=", "'; DROP TABLE--"]]
+
+
+class TestLooksLikeHtml:
+    """Advisory markup detection for chatter bodies."""
+
+    def test_detects_common_chatter_markup(self):
+        """Recognise the tags a formatted chatter message actually uses."""
+        for body in (
+            "<p>Hello</p>",
+            "first line<br/>second",
+            '<a href="https://example.com">Link</a>',
+            "<ul><li>one</li></ul>",
+            "<TABLE><TR><TD>x</TD></TR></TABLE>",
+            "<section>x</section>",
+        ):
+            assert tool_helpers.looks_like_html(body) is True, body
+
+    def test_leaves_prose_with_angle_brackets_alone(self):
+        """Plain prose must not be mistaken for markup.
+
+        These are the cases that make silent auto-conversion unsafe: each
+        one would lose visible text if it were treated as HTML.
+        """
+        for body in (
+            "Please forward to <a.schmidt@example.com>",
+            "<pre-check 2026> is still open",
+            "amount < 100 EUR & rest > 0",
+            "",
+        ):
+            assert tool_helpers.looks_like_html(body) is False, body
+
+    def test_false_positives_are_accepted_and_harmless(self):
+        """Some prose is genuinely indistinguishable from markup.
+
+        ``<b and b>`` is a syntactically valid tag with two valueless
+        attributes, so no pattern can rule it out. This is why the result
+        only ever produces a warning: the cost of being wrong here is one
+        superfluous sentence, never a transformed body. The matching
+        guarantee on the posting side is covered by
+        ``test_chatter_post_plain_body_is_unchanged``.
+        """
+        assert tool_helpers.looks_like_html("if a<b and b>c") is True
+
+    def test_handles_none_body(self):
+        """A missing body is not markup."""
+        assert tool_helpers.looks_like_html(None) is False


### PR DESCRIPTION
## Summary

Any markup passed to `chatter_post` arrives in the chatter as literal tags. Odoo escapes every `str` body handed to `message_post` — only a `markupsafe.Markup` survives, and RPC cannot carry one, so no caller of this tool can currently post a formatted message.

Odoo 17 added `message_post(body_is_html=...)` for exactly this case ("to be used only for RPC calls", `mail/models/mail_thread.py`). `chatter_post` now exposes a `body_is_html` parameter, forwards it on Odoo 17+, and omits it on 16, which stores bodies verbatim anyway.

**User-facing behavior change:** a new optional `body_is_html` parameter (default `false`). With it unset, behavior is byte-for-byte unchanged; the only addition is an advisory `warnings` entry when a body looks like markup but the flag is off.

### Why opt-in rather than auto-detected

Detection cannot separate markup from prose. Both of these are valid tag syntax:

- `Please forward to <a.schmidt@example.com>`
- `if a<b and b>c`

Treating either as HTML silently deletes the bracketed text when Odoo renders the field — a lossy failure worse than the escaped-tags one it would fix. So nothing is ever converted: `looks_like_html` exists only to raise the warning, and its accepted false positives are pinned by a test.

`body_is_html` is part of the canonical payload, so an approval previewed as plain text cannot be executed as markup.

## Coverage

Seven unit tests in `tests/test_server.py` (forwarding on 17, omission on 16, unchanged plain-text path, warning path, preview warning, token binding, gated round-trip) and a `looks_like_html` group in `tests/test_tool_helpers.py` including the deliberately accepted false positives. They use the existing `_ChatterClient` pattern and need no live Odoo.

## Verification

- Odoo versions: **17.0** end-to-end against a live instance — the stored `mail.message.body` comes back byte-for-byte as sent, unescaped. **16** is covered by unit test only, since the change there is the absence of the kwarg.
- Odoo transport: **XML-RPC**. MCP transport: **Streamable HTTP**.
- Exact commands:

```bash
uv run python -m ruff check .                  # All checks passed!
uv run python -m mypy src                      # Success: no issues found in 34 source files
uv run python -m pytest                        # 925 passed, 1 deselected
uv run python -m pytest tests/test_server.py   # 219 passed
```

The deselected test is `test_from_path_rejects_symlink_escape_within_upload_root`, which needs the Windows symlink privilege and fails on this machine both before and after the change.

## Checklist

- [x] Updated documentation (`README.md`, `docs/troubleshooting.md`)
- [x] Updated `CHANGELOG.md` under `## Unreleased`
- [x] No credentials or production data in the change
- [x] Regression test that the default plain-text path gains no new kwarg and rewrites nothing

## Relation to #61

No conflict expected: the `tools_write.py` regions are disjoint (`chatter_post` here, `_execute_approved_write_gated` there). Only `tests/test_server.py` and `CHANGELOG.md` are shared, both append-only.