### PR TITLE
fix(write): name validate_write as the step that registers an approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **`preview_write` pointed callers at the wrong next step.** Its warning named
+  only `execute_approved_write`, but `validate_write` is what registers the
+  approval, so following the warning verbatim always produced "approval token
+  has not been validated in this server session" — which reads like an
+  infrastructure fault and gets reported as one. The warning now names the
+  missing step, and the error itself states the TTL and warns against
+  re-sending the `sha256:` fingerprint in place of a `*_from_path` argument.
+
 ## [1.3.0] - 2026-07-29
 
 ### Changed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,7 +57,7 @@ record rule (Odoo masks unauthorized IDs as missing).
 | Symptom | Cause / fix |
 | --- | --- |
 | `write execution disabled` | Set `ODOO_MCP_ENABLE_WRITES=1` (writes are off by default). |
-| `approval token has not been validated` | Call `validate_write` (with live metadata) before `execute_approved_write`; tokens expire after 10 minutes and are session-bound. |
+| `approval token has not been validated` | The flow is three steps: `preview_write` → `validate_write` (with live metadata — this is the step that registers the approval) → `execute_approved_write`. A preview token alone is never executable. Approvals are held for the life of the server process — they survive across requests but not a restart — and expire after 10 minutes. |
 | `method ... is not allowed` on `execute_method` | Direct `create/write/unlink` are always blocked; side-effect methods need a review entry — see the policy file in [docs/architecture.md](./architecture.md) and `odoo_mcp_policy.json.example`. |
 | Hallucinated model names (`account.invoice`) | `lookup_model_history(name=...)` maps old names to current ones. |
 | Agent loops `read_record` | `health_check` → `runtime.n_plus_one.hot_models` flags it; batch with `search_records` and an `["id", "in", [...]]` domain. |

--- a/src/odoo_mcp/agent_tools.py
+++ b/src/odoo_mcp/agent_tools.py
@@ -250,8 +250,12 @@ def build_write_preview_report(
             {
                 "code": "destructive_operation",
                 "message": (
-                    "This preview does not execute. execute_approved_write is "
-                    "destructive and requires the matching approval token plus confirm=true."
+                    "This preview does not execute, and its token is not usable "
+                    "yet. Next: call validate_write with the same payload (that "
+                    "is what registers the approval), then execute_approved_write "
+                    "with the approval it returns plus confirm=true. Going "
+                    "straight to execute_approved_write fails with 'approval "
+                    "token has not been validated'."
                 ),
             }
         ],

--- a/src/odoo_mcp/tools_write.py
+++ b/src/odoo_mcp/tools_write.py
@@ -446,7 +446,13 @@ def _execute_approved_write_gated(
                 "tool": "execute_approved_write",
                 "error": (
                     "approval token has not been validated in this server session "
-                    "or has expired; call validate_write first"
+                    f"or has expired (approvals live {WRITE_APPROVAL_TTL_SECONDS}s). "
+                    "validate_write is the step that registers an approval — a "
+                    "preview_write token alone is never executable. Call "
+                    "validate_write, then execute_approved_write with the approval "
+                    "it returns. Re-send any *_from_path argument in its original "
+                    "form; the 'sha256:...' fingerprint echoed back by a previous "
+                    "call is not a usable file value."
                 ),
             }
         if write_approval_payload(approval) != validation_record.get("payload"):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1194,3 +1194,21 @@ def test_build_text_query_domain_rejects_blank_query():
 
     with pytest.raises(ValueError):
         agent_tools.build_text_query_domain("   ", {"name": _meta()})
+
+
+def test_preview_warning_names_validate_write_as_the_next_step():
+    """The warning that sent a user straight into the token error.
+
+    It described a two-step flow while the write path is three-step, so
+    following it verbatim always produced "approval token has not been
+    validated". The next tool to call must be named explicitly.
+    """
+    report = agent_tools.build_write_preview_report(
+        model="res.partner",
+        operation="write",
+        record_ids=[7],
+        values={"comment": "x"},
+    )
+    message = report["warnings"][0]["message"]
+    assert "validate_write" in message
+    assert message.index("validate_write") < message.index("execute_approved_write")


### PR DESCRIPTION
## Summary

`preview_write` returns this warning:

> This preview does not execute. execute_approved_write is destructive and requires the matching approval token plus confirm=true.

It never mentions `validate_write`, which is the only step that registers the approval (`register_write_approval`). A caller who follows the warning goes straight from `preview_write` to `execute_approved_write` and gets:

> approval token has not been validated in this server session or has expired

That reads like an infrastructure fault rather than a missing step. In our case it was first reported as a suspected session-affinity problem, and the misleading warning was only found after ruling that out — `write_approvals` lives on the per-lifespan `AppContext`, so an approval survives across requests for as long as the process does.

**User-facing behavior change:** wording only. The warning now names `validate_write` as the next call. The error it warns about now states the TTL and, for approvals staged from a local file, warns against re-sending the `sha256:...` fingerprint echoed back by an earlier call in place of the original `*_from_path` argument — doing so would write the fingerprint string into the binary field.

The message deliberately keeps "has not been validated ... or has expired" as one branch rather than splitting it. Once `_sweep_expired_write_approvals` has run, an expired approval is indistinguishable from one that was never validated, and telling a caller who did validate that they skipped the step would be worse than saying nothing.

## Coverage

`tests/test_agent_tools.py` asserts the preview warning names `validate_write` and names it *before* `execute_approved_write`, so the ordering that caused the confusion cannot silently come back. The existing `execute_approved_write` error-path tests in `tests/test_server.py` still pass against the new wording unchanged.

## Verification

- Odoo versions: **17.0**, confirmed against a live instance (`preview_write` → `validate_write` → `execute_approved_write` round-trip, plus the failure path).
- Odoo transport: **XML-RPC**. MCP transport: **Streamable HTTP**.
- Exact commands:

```bash
uv run python -m ruff check .                  # All checks passed!
uv run python -m mypy src                      # Success: no issues found in 34 source files
uv run python -m pytest                        # 915 passed, 1 deselected
uv run python -m pytest tests/test_server.py   # 212 passed
```

The deselected test is `test_from_path_rejects_symlink_escape_within_upload_root`, which needs the Windows symlink privilege and fails on this machine both before and after the change.

## Checklist

- [x] Updated documentation (`docs/troubleshooting.md`; `README.md`'s Safe Write Model already describes the three steps correctly — the defect was only in the tool's own warning text)
- [x] Updated `CHANGELOG.md` under `## Unreleased`
- [x] No credentials or production data in the change
- [x] No gate is loosened: this changes message strings and adds no new path

## Relation to #61

#61 moves this error into a new `_write_execution_state_error` helper and carries the old wording forward verbatim, so the two will conflict textually in `tools_write.py`. Whichever lands second, the resolution is to keep this wording inside that helper. Happy to rebase on top of #61 if you prefer to merge it first.